### PR TITLE
ARXIVNG-1364 Make endorsement status clear to submitter early in process

### DIFF
--- a/submit/config.py
+++ b/submit/config.py
@@ -91,7 +91,8 @@ URLS = [
     ("help_submit_html", "/help/submit_html", BASE_SERVER),
     ("help_metadata", "/help/prep", BASE_SERVER),
     ("help_jref", "/help/jref", BASE_SERVER),
-    ("help_withdraw", "/help/withdraw", BASE_SERVER)
+    ("help_withdraw", "/help/withdraw", BASE_SERVER),
+    ("help_endorse", "/help/endorsement", BASE_SERVER)
 ]
 """
 URLs for external services, for use with :func:`flask.url_for`.

--- a/submit/controllers/classification.py
+++ b/submit/controllers/classification.py
@@ -118,7 +118,8 @@ def classification(method: str, params: MultiDict, session: Session,
     response_data = {
         'submission_id': submission_id,
         'form': form,
-        'submission': submission
+        'submission': submission,
+        'submitter': submitter
     }
 
     if method == 'POST':

--- a/submit/controllers/verify_user.py
+++ b/submit/controllers/verify_user.py
@@ -52,6 +52,7 @@ def verify_user(method: str, params: MultiDict, session: Session,
         'submission_id': submission_id,
         'form': form,
         'submission': submission,
+        'submitter': submitter,
         'user': session.user,   # We want the most up-to-date representation.
     }
 
@@ -92,7 +93,8 @@ def verify_user(method: str, params: MultiDict, session: Session,
             return response_data, status.HTTP_400_BAD_REQUEST, {}
         response_data.update({
             'submission_id': submission_id,
-            'submission': submission
+            'submission': submission,
+            'submitter': submitter
         })
         return response_data, status.HTTP_303_SEE_OTHER, {}
     return response_data, status.HTTP_200_OK, {}

--- a/submit/routes/ui.py
+++ b/submit/routes/ui.py
@@ -6,7 +6,7 @@ from werkzeug import MultiDict
 from werkzeug.exceptions import InternalServerError
 from flask import Blueprint, make_response, redirect, request, \
                   render_template, url_for, Response, g
-from arxiv import status
+from arxiv import status, taxonomy
 from submit import controllers
 from arxiv.users import auth
 import arxiv.submission as events
@@ -591,3 +591,19 @@ def inject_get_next_stage_for_submission() -> Dict[str, Callable]:
         return url_for(f'ui.{stage.next_stage.value}',
                        submission_id=this_submission.submission_id)
     return {'get_next_stage_for_submission': get_next_stage_for_submission}
+
+
+@blueprint.app_template_filter()
+def endorsetype(endorsements):
+    """
+    Transmit endorsement status to template for message filtering.
+    Returns a string, for now.
+    """
+    if(len(endorsements) == 0):
+        return 'None'
+    elif(len(taxonomy.CATEGORIES_ACTIVE.keys()) - len(endorsements) == 0):
+        return 'All'
+    elif(len(taxonomy.CATEGORIES_ACTIVE.keys()) - len(endorsements) > 0):
+        return 'Some'
+    else:
+        return 'Error'

--- a/submit/routes/ui.py
+++ b/submit/routes/ui.py
@@ -594,10 +594,19 @@ def inject_get_next_stage_for_submission() -> Dict[str, Callable]:
 
 
 @blueprint.app_template_filter()
-def endorsetype(endorsements):
+def endorsetype(endorsements: List[str]) -> str:
     """
     Transmit endorsement status to template for message filtering.
-    Returns a string, for now.
+
+    Parameters
+    ----------
+    endorsements : list
+        The list of categories (str IDs) for which the user is endorsed.
+
+    Returns
+    -------
+    str
+        For now.
     """
     if(len(endorsements) == 0):
         return 'None'

--- a/submit/routes/ui.py
+++ b/submit/routes/ui.py
@@ -1,6 +1,6 @@
 """Provides routes for the submission user interface."""
 
-from typing import Optional, Callable, Dict
+from typing import Optional, Callable, Dict, List
 
 from werkzeug import MultiDict
 from werkzeug.exceptions import InternalServerError

--- a/submit/templates/submit/classification.html
+++ b/submit/templates/submit/classification.html
@@ -57,7 +57,7 @@
         <div class="message is-link submit-nav">
           <div class="message-body">
             <p class="has-text-weight-bold"><span class="icon has-text-link"><i class="fa fa-info-circle"></i></span>Favorites</p>
-            <p>Favorite categories are placed at the top of the selection list. You may add or remove favorites in your <a href="{{ url_for('account') }}">user account settings</a>.</p>
+            <p>Preferred categories are placed at the top of the selection list. You may add or remove favorites in your <a href="{{ url_for('account') }}">user account settings</a>.</p>
           </div>
         </div>
       {% endif %}

--- a/submit/templates/submit/classification.html
+++ b/submit/templates/submit/classification.html
@@ -38,11 +38,24 @@
     </div>
 
     <div class="column is-one-third-tablet is-half-desktop">
+      {% if not authorization.endorsements %}
+        <div class="message is-link">
+          <div class="message-body">
+            <p>No list options means no endorsement. It should be impossible to get to this page without endorsement, but if one does, show an appropriate message.</p>
+          </div>
+        </div>
+      {% endif %}
+      {% if set(taxonomy.CATEGORIES.active) - set(authorization.endorsements) %}
+        <div class="message is-link">
+          <div class="message-body">
+            <p>This list shows categories for which you are endorsed. If you wish to submit to a category not shown here, you will need to seek endorsement prior to submission.</p>
+          </div>
+        </div>
+      {% endif %}
       <div class="message is-link submit-nav">
         <div class="message-body">
-          <p><span class="icon has-text-link"><i class="fa fa-info-circle"></i></span>
-          You are registered to submit to < groups >.</p>
-          <p>You may add groups and change defaults in your <a href="{{ url_for('account') }}">user account settings</a>.</p>
+          <p class="has-text-weight-bold"><span class="icon has-text-link"><i class="fa fa-info-circle"></i></span>Favorites</p>
+          <p>Favorite categories are placed at the top of the selection list. You may add or remove favorites in your <a href="{{ url_for('account') }}">user account settings</a>.</p>
         </div>
       </div>
       <div class="message is-link">

--- a/submit/templates/submit/classification.html
+++ b/submit/templates/submit/classification.html
@@ -38,26 +38,29 @@
     </div>
 
     <div class="column is-one-third-tablet is-half-desktop">
-      {% if not authorization.endorsements %}
+      {% if submitter.endorsements|endorsetype == 'None' %}
         <div class="message is-link">
           <div class="message-body">
             <p>No list options means no endorsement. It should be impossible to get to this page without endorsement, but if one does, show an appropriate message.</p>
           </div>
         </div>
       {% endif %}
-      {% if set(taxonomy.CATEGORIES.active) - set(authorization.endorsements) %}
+      {% if submitter.endorsements|endorsetype == 'Some' %}
         <div class="message is-link">
           <div class="message-body">
-            <p>This list shows categories for which you are endorsed. If you wish to submit to a category not shown here, you will need to seek endorsement prior to submission.</p>
+            <p class="has-text-weight-bold"><span class="icon has-text-link"><i class="fa fa-info-circle"></i></span>Endorsements</p>
+            <p>This list shows only the categories for which you are endorsed. If you wish to submit to a category not shown here, you will need to <a href="{{ url_for('help_endorse') }}">seek endorsement</a> prior to submission.</p>
           </div>
         </div>
       {% endif %}
-      <div class="message is-link submit-nav">
-        <div class="message-body">
-          <p class="has-text-weight-bold"><span class="icon has-text-link"><i class="fa fa-info-circle"></i></span>Favorites</p>
-          <p>Favorite categories are placed at the top of the selection list. You may add or remove favorites in your <a href="{{ url_for('account') }}">user account settings</a>.</p>
+      {% if submitter.endorsements|endorsetype != 'None'  %}
+        <div class="message is-link submit-nav">
+          <div class="message-body">
+            <p class="has-text-weight-bold"><span class="icon has-text-link"><i class="fa fa-info-circle"></i></span>Favorites</p>
+            <p>Favorite categories are placed at the top of the selection list. You may add or remove favorites in your <a href="{{ url_for('account') }}">user account settings</a>.</p>
+          </div>
         </div>
-      </div>
+      {% endif %}
       <div class="message is-link">
         <div class="message-header">
           <p><span class="icon"><i class="fa fa-info-circle"></i></span> Choosing a Good Category</p>

--- a/submit/templates/submit/verify_user.html
+++ b/submit/templates/submit/verify_user.html
@@ -46,7 +46,18 @@
         </div>
       <p>Check this information carefully!</p>
       <p>A <span class="has-text-weight-bold">current email address is required</span> to complete your submission.</p>
-      <p><a class="button" href="{{ url_for('account') }}">Edit User Information</a>
+      <p><a class="button" href="{{ url_for('account') }}">Edit User Information</a></p>
+      </div>
+    </div>
+    <div class="message is-warning">
+      <div class="message-header">
+        <p>Endorsements</p>
+      </div>
+      <div class="message-body">
+        <div class="is-pulled-left">
+          <span class="icon has-text-link"><i class="fa fa-exclamation-triangle"></i></span>
+        </div>
+      <p>You are endorsed for: {{ authorization.endorsements }}</p>
       </div>
     </div>
   </div>

--- a/submit/templates/submit/verify_user.html
+++ b/submit/templates/submit/verify_user.html
@@ -57,7 +57,17 @@
         <div class="is-pulled-left">
           <span class="icon has-text-link"><i class="fa fa-exclamation-triangle"></i></span>
         </div>
-      <p>You are endorsed for: {{ authorization.endorsements }}</p>
+      <p>You are endorsed for: </p>
+      <ul>
+      {% for endorsement in submitter.endorsements %}
+        <li>{{ endorsement }}</li>
+      {% endfor %}
+      </ul>
+      <p>If you wish to submit to a category not listed here, you will need to seek endorsement before submitting.</p>
+      <p>Type: {{ submitter.endorsements|endorsetype }}</p>
+      {% if submitter.endorsements|endorsetype == 'Some' %}
+      <p>Boo!</p>
+      {% endif %}
       </div>
     </div>
   </div>

--- a/submit/templates/submit/verify_user.html
+++ b/submit/templates/submit/verify_user.html
@@ -49,27 +49,38 @@
       <p><a class="button" href="{{ url_for('account') }}">Edit User Information</a></p>
       </div>
     </div>
-    <div class="message is-warning">
+    {% if submitter.endorsements|endorsetype == 'Some' %}
+      <div class="message is-warning">
+        <div class="message-header">
+          <p>Endorsements</p>
+        </div>
+        <div class="message-body">
+          <div class="is-pulled-left">
+            <span class="icon has-text-link"><i class="fa fa-exclamation-triangle"></i></span>
+          </div>
+          <p>You are currently endorsed for: </p>
+          <ul>
+          {% for endorsement in submitter.endorsements %}
+            <li>{{ endorsement }}</li>
+          {% endfor %}
+          </ul>
+          <p>If you wish to submit to a category other than those listed, you will need to <a href="{{ url_for('help_endorse') }}">seek endorsement</a> before submitting.</p>
+        </div>
+      </div>
+    {% endif %}
+    {% if submitter.endorsements|endorsetype == 'None' %}
+    <div class="message is-danger">
       <div class="message-header">
         <p>Endorsements</p>
       </div>
       <div class="message-body">
         <div class="is-pulled-left">
-          <span class="icon has-text-link"><i class="fa fa-exclamation-triangle"></i></span>
+          <span class="icon"><i class="fa fa-exclamation-triangle"></i></span>
         </div>
-      <p>You are endorsed for: </p>
-      <ul>
-      {% for endorsement in submitter.endorsements %}
-        <li>{{ endorsement }}</li>
-      {% endfor %}
-      </ul>
-      <p>If you wish to submit to a category not listed here, you will need to seek endorsement before submitting.</p>
-      <p>Type: {{ submitter.endorsements|endorsetype }}</p>
-      {% if submitter.endorsements|endorsetype == 'Some' %}
-      <p>Boo!</p>
-      {% endif %}
+        <p>Your account does not currently have any endorsed categories. You will need to <a href="{{ url_for('help_endorse') }}">seek endorsement</a> before submitting.</p>
       </div>
     </div>
+    {% endif %}
   </div>
 </div>
 


### PR DESCRIPTION
I added a little Jinja filter that checks the number of endorsements against the list of currently active categories. Currently a little tricky to test, since it's hard to generate test users with endorsements that match all/none conditions.

The verify-user step displays a notice if a submitter doesn't have auto endorsements. It's a warning for "Some" and a danger for "None". Outstanding task: gatekeeping/validation on this stage for endorsement status "None".

![screen shot 2018-12-17 at 3 54 42 pm](https://user-images.githubusercontent.com/17456668/50117236-68132080-021a-11e9-9c94-3ca55230b1ad.png)
---
Then, the classification step shows messages dependent on that endorsement status. It shows just the "Favorites" box for endorsements = all.

![screen shot 2018-12-17 at 3 56 02 pm](https://user-images.githubusercontent.com/17456668/50117271-82e59500-021a-11e9-898d-150fd9ea40de.png)
