### PR TITLE
ARXIVNG-1369 adding abs preview

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -16,8 +16,7 @@ bleach = "*"
 requests = "==2.19.1"
 arxiv-auth = "==0.2.0rc1"
 arxiv-base = "==0.12.1rc2"
-arxiv-submission-core = "==0.5.3rc3"
-"3a3786f" = {path = "./../arxiv-submission-core/core"}
+arxiv-submission-core = "==0.5.3rc4"
 
 [dev-packages]
 pylint = "*"

--- a/Pipfile
+++ b/Pipfile
@@ -15,8 +15,9 @@ SQLAlchemy = "*"
 bleach = "*"
 requests = "==2.19.1"
 arxiv-auth = "==0.2.0rc1"
-arxiv-base = "==0.11.1"
+arxiv-base = "==0.12.1rc2"
 arxiv-submission-core = "==0.5.3rc3"
+"3a3786f" = {path = "./../arxiv-submission-core/core"}
 
 [dev-packages]
 pylint = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "dd0722dcabc6940d447a5af5df1201531325280582a51a5f3acc2346ed91268c"
+            "sha256": "64ec922df2938005d3c7863b778d6c7e1b2049c9daf36383c928866aeba539ad"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -33,10 +33,10 @@
         },
         "arxiv-submission-core": {
             "hashes": [
-                "sha256:8fb5a3272f704110c199eff61bff56df29377ddf225376df5f378d19c163fda1"
+                "sha256:2f314fd6bc6e146485ee5792b03e3315bf126981974ad50ea5685c99c44a6feb"
             ],
             "index": "pypi",
-            "version": "==0.5.3rc3"
+            "version": "==0.5.3rc4"
         },
         "bleach": {
             "hashes": [
@@ -48,17 +48,17 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:a2f8c0cbb63abd5f1908f9b95a00916eba45144b13871c6b6cbd0ed365277077",
-                "sha256:c5d14d88c220c71490687905bd192c452e1131b4519bf0cf8a0c552cf1d40015"
+                "sha256:09d1ae44f15659e425b7526de452bfa3840e12dd3e08dd0b067a78f619e997b5",
+                "sha256:88233f9bdc1e6ee58c9489cef6c573bf7e660acfcc1597bc3ff765a065e1a0f0"
             ],
-            "version": "==1.9.67"
+            "version": "==1.9.68"
         },
         "botocore": {
             "hashes": [
-                "sha256:033efb6ea10d06404431f5f5fe86ecb3bccb17458960740da661b981f09359c7",
-                "sha256:4a091f5296da00e4e552637101d5fa4f4c87fa888ee88e99e09127fe15176aec"
+                "sha256:7fd7954f19a49c9794bed696c801f3dfd7bdde306d17c9bb9fb0c069e6b42e5a",
+                "sha256:f6dc444ca92f33e1a3129e39b2c6d9941e4931fda3f3aff02fe82290013ef2d0"
             ],
-            "version": "==1.12.67"
+            "version": "==1.12.68"
         },
         "certifi": {
             "hashes": [
@@ -201,6 +201,7 @@
                 "sha256:063df5763652e21de43de7d9e00ccf239f953a832941e37be541614732cdfc93",
                 "sha256:88f9287c0174266bb0d8cedd395cfba9c58e87e5ad86b2ce58859bc11be3cf02"
             ],
+            "markers": "python_version >= '2.7'",
             "version": "==2.7.5"
         },
         "pytz": {
@@ -275,7 +276,6 @@
                 "sha256:a68ac5e15e76e7e5dd2b8f94007233e01effe3e50e8daddf69acfd81cb686baf",
                 "sha256:b5725a0bd4ba422ab0e66e89e030c806576753ea3ee08554382c14e685d117b5"
             ],
-            "markers": "python_version >= '3.4'",
             "version": "==1.23"
         },
         "uwsgi": {
@@ -539,6 +539,7 @@
                 "sha256:f741ba03feb480061ab91a465d1a3ed2d40b52822ada5b4017770dfcb88f839f",
                 "sha256:fe800a58547dd424cd286b7270b967b5b3316b993d86453ede184a17b5a6b17d"
             ],
+            "markers": "python_version < '3.7' and implementation_name == 'cpython'",
             "version": "==1.1.1"
         },
         "urllib3": {
@@ -546,7 +547,6 @@
                 "sha256:a68ac5e15e76e7e5dd2b8f94007233e01effe3e50e8daddf69acfd81cb686baf",
                 "sha256:b5725a0bd4ba422ab0e66e89e030c806576753ea3ee08554382c14e685d117b5"
             ],
-            "markers": "python_version >= '3.4'",
             "version": "==1.23"
         },
         "wrapt": {

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "2a5565f5e32de2f9522ff87fff2b156e03725784d2b61f03531784f21cd9460f"
+            "sha256": "dd0722dcabc6940d447a5af5df1201531325280582a51a5f3acc2346ed91268c"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -14,6 +14,9 @@
         ]
     },
     "default": {
+        "3a3786f": {
+            "path": "./../arxiv-submission-core/core"
+        },
         "arxiv-auth": {
             "hashes": [
                 "sha256:c391381cc94b83a9173c383b78b06d5a77d5d124d5686577ba8466e68012fd80"
@@ -23,10 +26,10 @@
         },
         "arxiv-base": {
             "hashes": [
-                "sha256:159a2c54ce7f0d562c5df28318b92086df8155e7aa29f7586835b9aaab74b749"
+                "sha256:9896b4f54d4a5e20c5f7ab7e8c65aa022781f8eba149b9730896fe22a44e0535"
             ],
             "index": "pypi",
-            "version": "==0.11.1"
+            "version": "==0.12.1rc2"
         },
         "arxiv-submission-core": {
             "hashes": [
@@ -45,17 +48,17 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:4f52d5345a2dcaae62f03d194416ec7461faf367b4d885e6319c62fcef5f6a42",
-                "sha256:6e9f48f3cd16f4b4e1e2d9c49c0644568294f67cda1a93f84315526cbd7e70ae"
+                "sha256:a2f8c0cbb63abd5f1908f9b95a00916eba45144b13871c6b6cbd0ed365277077",
+                "sha256:c5d14d88c220c71490687905bd192c452e1131b4519bf0cf8a0c552cf1d40015"
             ],
-            "version": "==1.9.60"
+            "version": "==1.9.67"
         },
         "botocore": {
             "hashes": [
-                "sha256:ad523b7e530b8fd51b8207ad1c981852399ec8f21b2c32311139daa8b2cbb55e",
-                "sha256:e298eaa3883d5aa62a21e84b68a3b4d47b582fffdb93efefe53144d2ed9a824c"
+                "sha256:033efb6ea10d06404431f5f5fe86ecb3bccb17458960740da661b981f09359c7",
+                "sha256:4a091f5296da00e4e552637101d5fa4f4c87fa888ee88e99e09127fe15176aec"
             ],
-            "version": "==1.12.60"
+            "version": "==1.12.67"
         },
         "certifi": {
             "hashes": [
@@ -181,18 +184,17 @@
         },
         "pycountry": {
             "hashes": [
-                "sha256:195d8174fd6f98f45622d2885826091fc8b2168184422dac574311073ab8386c",
-                "sha256:7f2aa2529c60f6575af3cd644688b201b97016822ce0ce1c4bcc0f7d08900997",
-                "sha256:ea38f839e719be54dfae1b089cbf1917add6ff8f43a55533d8c7c5799656a848"
+                "sha256:104a8ca94c700898c42a0172da2eab5a5675c49637b729a11db9e1dac2d983cd",
+                "sha256:8ec4020b2b15cd410893d573820d42ee12fe50365332e58c0975c953b60a16de"
             ],
-            "version": "==18.5.26"
+            "version": "==18.12.8"
         },
         "pyjwt": {
             "hashes": [
-                "sha256:00414bfef802aaecd8cc0d5258b6cb87bd8f553c2986c2c5f29b19dd5633aeb7",
-                "sha256:ddec8409c57e9d371c6006e388f91daf3b0b43bdf9fcbf99451fb7cf5ce0a86d"
+                "sha256:5c6eca3c2940464d106b99ba83b00c6add741c9becaec087fb7ccdefea71350e",
+                "sha256:8d59a976fb773f3e6a39c85636357c4f0e242707394cadadd9814f5cbaa20e96"
             ],
-            "version": "==1.7.0"
+            "version": "==1.7.1"
         },
         "python-dateutil": {
             "hashes": [
@@ -256,17 +258,17 @@
         },
         "six": {
             "hashes": [
-                "sha256:70e8a77beed4562e7f14fe23a786b54f6296e34344c23bc42f07b15018ff98e9",
-                "sha256:832dc0e10feb1aa2c68dcc57dbb658f1c7e65b9b61af69048abc87a2db00a0eb"
+                "sha256:3350809f0555b11f552448330d0b52d5f24c91a322ea4a15ef22629740f3761c",
+                "sha256:d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73"
             ],
-            "version": "==1.11.0"
+            "version": "==1.12.0"
         },
         "sqlalchemy": {
             "hashes": [
-                "sha256:9de7c7dabcf06319becdb7e15099c44e5e34ba7062f9ba10bc00e562f5db3d04"
+                "sha256:809547455d012734b4252081db1e6b4fc731de2299f3755708c39863625e1c77"
             ],
             "index": "pypi",
-            "version": "==1.2.14"
+            "version": "==1.2.15"
         },
         "urllib3": {
             "hashes": [
@@ -446,19 +448,19 @@
         },
         "mimesis": {
             "hashes": [
-                "sha256:2a17aa98cc8aff2c0b1828312e213a515030ed57a1c7b61fc07a87150cb0f25f",
-                "sha256:4b856023acdaaefe2e10bbfea9fd4cb6fa9adbbbe9618a8f796aa8887b58e6f2"
+                "sha256:4384fec11d659cd5e6316a524467b29600f14d4c81ac93bcdd3b237cab03b3fe",
+                "sha256:702d74fc8984d593086a5e92f0d55a148629e57ccaf6fc5b875f056a3174435e"
             ],
             "index": "pypi",
-            "version": "==2.1.0"
+            "version": "==3.0.0"
         },
         "mypy": {
             "hashes": [
-                "sha256:8e071ec32cc226e948a34bbb3d196eb0fd96f3ac69b6843a5aff9bd4efa14455",
-                "sha256:fb90c804b84cfd8133d3ddfbd630252694d11ccc1eb0166a1b2efb5da37ecab2"
+                "sha256:12d965c9c4e8a625673aec493162cf390e66de12ef176b1f4821ac00d55f3ab3",
+                "sha256:38d5b5f835a81817dcc0af8d155bce4e9aefa03794fe32ed154d6612e83feafa"
             ],
             "index": "pypi",
-            "version": "==0.641"
+            "version": "==0.650"
         },
         "mypy-extensions": {
             "hashes": [
@@ -501,10 +503,10 @@
         },
         "six": {
             "hashes": [
-                "sha256:70e8a77beed4562e7f14fe23a786b54f6296e34344c23bc42f07b15018ff98e9",
-                "sha256:832dc0e10feb1aa2c68dcc57dbb658f1c7e65b9b61af69048abc87a2db00a0eb"
+                "sha256:3350809f0555b11f552448330d0b52d5f24c91a322ea4a15ef22629740f3761c",
+                "sha256:d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73"
             ],
-            "version": "==1.11.0"
+            "version": "==1.12.0"
         },
         "snowballstemmer": {
             "hashes": [
@@ -515,31 +517,29 @@
         },
         "typed-ast": {
             "hashes": [
-                "sha256:0948004fa228ae071054f5208840a1e88747a357ec1101c17217bfe99b299d58",
-                "sha256:10703d3cec8dcd9eef5a630a04056bbc898abc19bac5691612acba7d1325b66d",
-                "sha256:1f6c4bd0bdc0f14246fd41262df7dfc018d65bb05f6e16390b7ea26ca454a291",
-                "sha256:25d8feefe27eb0303b73545416b13d108c6067b846b543738a25ff304824ed9a",
-                "sha256:29464a177d56e4e055b5f7b629935af7f49c196be47528cc94e0a7bf83fbc2b9",
-                "sha256:2e214b72168ea0275efd6c884b114ab42e316de3ffa125b267e732ed2abda892",
-                "sha256:3e0d5e48e3a23e9a4d1a9f698e32a542a4a288c871d33ed8df1b092a40f3a0f9",
-                "sha256:519425deca5c2b2bdac49f77b2c5625781abbaf9a809d727d3a5596b30bb4ded",
-                "sha256:57fe287f0cdd9ceaf69e7b71a2e94a24b5d268b35df251a88fef5cc241bf73aa",
-                "sha256:668d0cec391d9aed1c6a388b0d5b97cd22e6073eaa5fbaa6d2946603b4871efe",
-                "sha256:68ba70684990f59497680ff90d18e756a47bf4863c604098f10de9716b2c0bdd",
-                "sha256:6de012d2b166fe7a4cdf505eee3aaa12192f7ba365beeefaca4ec10e31241a85",
-                "sha256:79b91ebe5a28d349b6d0d323023350133e927b4de5b651a8aa2db69c761420c6",
-                "sha256:8550177fa5d4c1f09b5e5f524411c44633c80ec69b24e0e98906dd761941ca46",
-                "sha256:898f818399cafcdb93cbbe15fc83a33d05f18e29fb498ddc09b0214cdfc7cd51",
-                "sha256:94b091dc0f19291adcb279a108f5d38de2430411068b219f41b343c03b28fb1f",
-                "sha256:a26863198902cda15ab4503991e8cf1ca874219e0118cbf07c126bce7c4db129",
-                "sha256:a8034021801bc0440f2e027c354b4eafd95891b573e12ff0418dec385c76785c",
-                "sha256:bc978ac17468fe868ee589c795d06777f75496b1ed576d308002c8a5756fb9ea",
-                "sha256:c05b41bc1deade9f90ddc5d988fe506208019ebba9f2578c622516fd201f5863",
-                "sha256:c9b060bd1e5a26ab6e8267fd46fc9e02b54eb15fffb16d112d4c7b1c12987559",
-                "sha256:edb04bdd45bfd76c8292c4d9654568efaedf76fe78eb246dde69bdb13b2dad87",
-                "sha256:f19f2a4f547505fe9072e15f6f4ae714af51b5a681a97f187971f50c283193b6"
+                "sha256:0555eca1671ebe09eb5f2176723826f6f44cca5060502fea259de9b0e893ab53",
+                "sha256:0ca96128ea66163aea13911c9b4b661cb345eb729a20be15c034271360fc7474",
+                "sha256:16ccd06d614cf81b96de42a37679af12526ea25a208bce3da2d9226f44563868",
+                "sha256:1e21ae7b49a3f744958ffad1737dfbdb43e1137503ccc59f4e32c4ac33b0bd1c",
+                "sha256:37670c6fd857b5eb68aa5d193e14098354783b5138de482afa401cc2644f5a7f",
+                "sha256:46d84c8e3806619ece595aaf4f37743083f9454c9ea68a517f1daa05126daf1d",
+                "sha256:5b972bbb3819ece283a67358103cc6671da3646397b06e7acea558444daf54b2",
+                "sha256:6306ffa64922a7b58ee2e8d6f207813460ca5a90213b4a400c2e730375049246",
+                "sha256:6cb25dc95078931ecbd6cbcc4178d1b8ae8f2b513ae9c3bd0b7f81c2191db4c6",
+                "sha256:7e19d439fee23620dea6468d85bfe529b873dace39b7e5b0c82c7099681f8a22",
+                "sha256:7f5cd83af6b3ca9757e1127d852f497d11c7b09b4716c355acfbebf783d028da",
+                "sha256:81e885a713e06faeef37223a5b1167615db87f947ecc73f815b9d1bbd6b585be",
+                "sha256:94af325c9fe354019a29f9016277c547ad5d8a2d98a02806f27a7436b2da6735",
+                "sha256:b1e5445c6075f509d5764b84ce641a1535748801253b97f3b7ea9d948a22853a",
+                "sha256:cb061a959fec9a514d243831c514b51ccb940b58a5ce572a4e209810f2507dcf",
+                "sha256:cc8d0b703d573cbabe0d51c9d68ab68df42a81409e4ed6af45a04a95484b96a5",
+                "sha256:da0afa955865920edb146926455ec49da20965389982f91e926389666f5cf86a",
+                "sha256:dc76738331d61818ce0b90647aedde17bbba3d3f9e969d83c1d9087b4f978862",
+                "sha256:e7ec9a1445d27dbd0446568035f7106fa899a36f55e52ade28020f7b3845180d",
+                "sha256:f741ba03feb480061ab91a465d1a3ed2d40b52822ada5b4017770dfcb88f839f",
+                "sha256:fe800a58547dd424cd286b7270b967b5b3316b993d86453ede184a17b5a6b17d"
             ],
-            "version": "==1.1.0"
+            "version": "==1.1.1"
         },
         "urllib3": {
             "hashes": [

--- a/submit/controllers/withdraw.py
+++ b/submit/controllers/withdraw.py
@@ -49,7 +49,7 @@ def request_withdrawal(method: str, params: MultiDict, session: Session,
 
     # Will raise NotFound if there is no such submission.
     submission, submission_events = load_submission(submission_id)
-    print("meta", submission.metadata)
+
     # The submission must be published for this to be a withdrawal request.
     if not submission.published:
         alerts.flash_failure(Markup("Submission must first be published. See "

--- a/submit/controllers/withdraw.py
+++ b/submit/controllers/withdraw.py
@@ -49,7 +49,7 @@ def request_withdrawal(method: str, params: MultiDict, session: Session,
 
     # Will raise NotFound if there is no such submission.
     submission, submission_events = load_submission(submission_id)
-
+    print("meta", submission.metadata)
     # The submission must be published for this to be a withdrawal request.
     if not submission.published:
         alerts.flash_failure(Markup("Submission must first be published. See "

--- a/submit/routes/auth.py
+++ b/submit/routes/auth.py
@@ -9,4 +9,5 @@ from submit.util import load_submission
 def can_edit_submission(session: Session, submission_id: str, **kw) -> bool:
     """Check whether the user has privileges to edit a submission."""
     submission, submission_events = load_submission(submission_id)
-    return submission.owner.native_id == session.user.user_id
+    print(submission.owner.native_id, session.user.user_id, submission.owner.native_id == session.user.user_id)
+    return str(submission.owner.native_id) == session.user.user_id

--- a/submit/templates/submit/final_preview.html
+++ b/submit/templates/submit/final_preview.html
@@ -5,8 +5,28 @@
 {% block within_content %}
 <h2 class="is-size-4">Preview and approve your submission</h2>
 
-Final arXiv abstract preview (how it will appear on the website)
-preview
+{% if submission.version > 1 %}
+  {% let arxiv_id = submission.arxiv_id %}
+{% else %}
+  {% let arxiv_id = "0000.00000" %}
+{% endif %}
+
+{{ macros.abs(
+  arxiv_id,
+  submission.metadata.title,
+  submission.metadata.authors_display,
+  submission.metadata.abstract,
+  submission.created,
+  submission.primary_classification.category,
+  comments = submission.metadata.comments,
+  msc_class = submission.metadata.msc_class,
+  acm_class = submission.metadata.acm_class,
+  journal_ref = submission.metadata.journal_ref,
+  doi = submission.metadata.doi,
+  report_num = submission.metadata.report_num,
+  version = submission.version,
+  submission_history = [],
+  secondary_categories = submission.secondary_categories) }}
 
 Final PDF Preview
 

--- a/submit/templates/submit/jref.html
+++ b/submit/templates/submit/jref.html
@@ -18,17 +18,22 @@
   </div>
 
   <div class="box">
-    <p>The abs-page preview goes here, and shows these values in context.</p>
-    <dl>
-      <dt>DOI</dt>
-      <dd>{{ form.doi.data }}</dd>
-
-      <dt>Journal Reference</dt>
-      <dd>{{ form.journal_ref.data }}</dd>
-
-      <dt>Report Number</dt>
-      <dd>{{ form.report_num.data }}</dd>
-    </dl>
+    {{ macros.abs(
+      submission.arxiv_id,
+      submission.metadata.title,
+      submission.metadata.authors_display,
+      submission.metadata.abstract,
+      submission.created,
+      submission.primary_classification.category,
+      comments = submission.metadata.comments,
+      msc_class = submission.metadata.msc_class,
+      acm_class = submission.metadata.acm_class,
+      journal_ref = submission.metadata.journal_ref,
+      doi = submission.metadata.doi,
+      report_num = submission.metadata.report_num,
+      version = submission.version,
+      submission_history = [],
+      secondary_categories = submission.secondary_categories) }}
   </div>
   {% else %}
     <h2>arXiv:{{ submission.arxiv_id }}v{{ submission.version }} {{ submission.metadata.title }}</h2>

--- a/submit/templates/submit/jref.html
+++ b/submit/templates/submit/jref.html
@@ -28,9 +28,9 @@
       comments = submission.metadata.comments,
       msc_class = submission.metadata.msc_class,
       acm_class = submission.metadata.acm_class,
-      journal_ref = submission.metadata.journal_ref,
-      doi = submission.metadata.doi,
-      report_num = submission.metadata.report_num,
+      journal_ref = form.journal_ref.data,
+      doi = form.doi.data,
+      report_num = form.report_num.data,
       version = submission.version,
       submission_history = [],
       secondary_categories = submission.secondary_categories) }}

--- a/submit/templates/submit/withdraw.html
+++ b/submit/templates/submit/withdraw.html
@@ -18,11 +18,22 @@
   </div>
 
   <div class="box">
-    <p>The abs-page preview goes here, and shows these values in context.</p>
-    <dl>
-      <dt>Withdrawal reason</dt>
-      <dd>{{ form.withdrawal_reason.data }}</dd>
-    </dl>
+    {{ macros.abs(
+      submission.arxiv_id,
+      submission.metadata.title,
+      submission.metadata.authors_display,
+      submission.metadata.abstract,
+      submission.created,
+      submission.primary_classification.category,
+      comments = submission.metadata.comments,
+      msc_class = submission.metadata.msc_class,
+      acm_class = submission.metadata.acm_class,
+      journal_ref = submission.metadata.journal_ref,
+      doi = submission.metadata.doi,
+      report_num = submission.metadata.report_num,
+      version = submission.version,
+      submission_history = [],
+      secondary_categories = submission.secondary_categories) }}
   </div>
   {% else %}
   <h2>arXiv:{{ submission.arxiv_id }}v{{ submission.version }} {{ submission.metadata.title }}</h2>

--- a/submit/templates/submit/withdraw.html
+++ b/submit/templates/submit/withdraw.html
@@ -2,6 +2,10 @@
 
 {% import "submit/submit_macros.html" as submit_macros %}
 
+{%- macro comments_preview(comments, withdrawal_reason) -%}
+{{ comments }} Withdrawn: {{ withdrawal_reason}}
+{% endmacro %}
+
 {% block addl_head %}
  <link rel="stylesheet" href="{{ url_for('static', filename='css/submit.css')}}" />
  <script src="{{ url_for('static', filename='js/filewidget.js') }}"></script>
@@ -25,7 +29,7 @@
       submission.metadata.abstract,
       submission.created,
       submission.primary_classification.category,
-      comments = submission.metadata.comments,
+      comments = comments_preview(submission.metadata.comments, form.withdrawal_reason.data),
       msc_class = submission.metadata.msc_class,
       acm_class = submission.metadata.acm_class,
       journal_ref = submission.metadata.journal_ref,

--- a/submit/util.py
+++ b/submit/util.py
@@ -51,9 +51,22 @@ def publish_submission(submission_id: int) -> None:
     i = events.services.classic._get_head_idx(dbss)
     head = dbss[i]
     session = events.services.classic.current_session()
-    if head.is_published():
-        return
-    head.status = events.services.classic.models.Submission.PUBLISHED
+    if not head.is_published():
+        head.status = events.services.classic.models.Submission.PUBLISHED
+    head.title = "This is a fake title generated just now"
+    head.abstract = ("Spicy jalapeno bacon ipsum dolor amet strip steak"
+                     " andouille fatback exercitation chicken pork belly"
+                     " dolore pork ham hock. Pastrami meatball nisi ad, salami"
+                     " turducken aute sed dolore kevin in. Nostrud fatback"
+                     " eiusmod nulla buffalo pastrami, ut consequat venison."
+                     " Short loin eiusmod laborum shoulder veniam fugiat bacon"
+                     " et sint. Landjaeger kevin nostrud, occaecat tenderloin"
+                     " mollit laboris chicken swine burgdoggen id duis ut"
+                     " boudin.")
+    head.comments = "We added these comments when faking the publish."
+    head.doi = "10.1109/5.771073"
+    head.authors = "J. Bloggs, F. Doe, N. Body (FSU)"
+    print(head.__dict__)
     if head.document is None:
         paper_id = datetime.now().strftime('%s')[-4:] \
             + "." \


### PR DESCRIPTION
Here's what it looks like on the withdrawal page:

![image](https://user-images.githubusercontent.com/3451594/50192613-05488480-0301-11e9-86e2-21c87df47cac.png)

Here's what it looks like on the JREF page:

![image](https://user-images.githubusercontent.com/3451594/50192664-39bc4080-0301-11e9-9fdc-db3339d7c89e.png)

It's all wired up on the final preview page, but we can't see that yet...

Looking for any major show-stopper at this point. We'll need to re-verify this feature once the rest of the workflow is up and running. Hope to merge tomorrow (Dec 19) barring any blocking problems.