### PR TITLE
ARXIVNG-1451 ARXIVNG-1423 submitter endorsement display on verify user step

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -15,7 +15,7 @@ SQLAlchemy = "*"
 bleach = "*"
 requests = "==2.19.1"
 arxiv-base = "==0.12.1"
-arxiv-submission-core = "==0.6.1"
+arxiv-submission-core = "==0.6.2rc1"
 arxiv-auth = "==0.2.6rc1"
 
 [dev-packages]

--- a/Pipfile
+++ b/Pipfile
@@ -15,8 +15,8 @@ SQLAlchemy = "*"
 bleach = "*"
 requests = "==2.19.1"
 arxiv-base = "==0.12.1"
-arxiv-submission-core = "==0.6.2rc1"
 arxiv-auth = "==0.2.6rc1"
+arxiv-submission-core = "==0.6.2rc2"
 
 [dev-packages]
 pylint = "*"

--- a/Pipfile
+++ b/Pipfile
@@ -14,9 +14,9 @@ pytz = "*"
 SQLAlchemy = "*"
 bleach = "*"
 requests = "==2.19.1"
-arxiv-auth = "==0.2.0rc1"
 arxiv-base = "==0.12.1"
-arxiv-submission-core = "==0.5.3rc4"
+arxiv-submission-core = "==0.6.1"
+"825942b" = {path = "./../arxiv-auth/users"}
 
 [dev-packages]
 pylint = "*"

--- a/Pipfile
+++ b/Pipfile
@@ -16,7 +16,7 @@ bleach = "*"
 requests = "==2.19.1"
 arxiv-base = "==0.12.1"
 arxiv-submission-core = "==0.6.1"
-"825942b" = {path = "./../arxiv-auth/users"}
+arxiv-auth = "==0.2.6rc1"
 
 [dev-packages]
 pylint = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "5dda34735d0f14fe7b58f0e4eb10e81b9f030ecce711490c44f114ac3c7908a9"
+            "sha256": "3d851fdf75042949e9c6b6545df80ce13bc8500a801d7844062c10e4c9893643"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -14,9 +14,6 @@
         ]
     },
     "default": {
-        "825942b": {
-            "path": "./../arxiv-auth/users"
-        },
         "amqp": {
             "hashes": [
                 "sha256:9f181e4aef6562e6f9f45660578fc1556150ca06e836ecb9e733e6ea10b48464",
@@ -26,9 +23,10 @@
         },
         "arxiv-auth": {
             "hashes": [
-                "sha256:5e4d2e2155fde458653142613c614fced9f3bc6021d8e3e1c0dd2cd9b0279701"
+                "sha256:b547f31fb6ca1acb365550bce130bdde3e0aaa6ac05a57a9b84c306e2daad92d"
             ],
-            "version": "==0.2.5"
+            "index": "pypi",
+            "version": "==0.2.6rc1"
         },
         "arxiv-base": {
             "hashes": [
@@ -308,6 +306,7 @@
                 "sha256:a68ac5e15e76e7e5dd2b8f94007233e01effe3e50e8daddf69acfd81cb686baf",
                 "sha256:b5725a0bd4ba422ab0e66e89e030c806576753ea3ee08554382c14e685d117b5"
             ],
+            "markers": "python_version >= '3.4'",
             "version": "==1.23"
         },
         "uwsgi": {
@@ -586,6 +585,7 @@
                 "sha256:a68ac5e15e76e7e5dd2b8f94007233e01effe3e50e8daddf69acfd81cb686baf",
                 "sha256:b5725a0bd4ba422ab0e66e89e030c806576753ea3ee08554382c14e685d117b5"
             ],
+            "markers": "python_version >= '3.4'",
             "version": "==1.23"
         },
         "wrapt": {

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "3d851fdf75042949e9c6b6545df80ce13bc8500a801d7844062c10e4c9893643"
+            "sha256": "b81e71c76abd07fef345161f5850366f6b4adad75e42548d369de6624a7f0a4f"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -37,10 +37,10 @@
         },
         "arxiv-submission-core": {
             "hashes": [
-                "sha256:b188c3e4852136e773b553b47b2733583acabadde4ee4bda7a77f212c106b325"
+                "sha256:f7d21d2ab23d8ea1771f029c26a79eb1c0c4a1d9384fd14cbcfc0e54eac9de03"
             ],
             "index": "pypi",
-            "version": "==0.6.1"
+            "version": "==0.6.2rc1"
         },
         "billiard": {
             "hashes": [
@@ -577,7 +577,6 @@
                 "sha256:f5be39a0146be663cbf210a4d95c3c58b2d7df7b043c9047c5448e358f0550a2",
                 "sha256:fcd198bf19d9213e5cbf2cde2b9ef20a9856e716f76f9476157f90ae6de06cc6"
             ],
-            "markers": "python_version < '3.7' and implementation_name == 'cpython'",
             "version": "==1.2.0"
         },
         "urllib3": {

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "ebfc40e702ec7fccd2466a1c54a8bfb9ada792ec2a5bb7ff21426300201eeaaa"
+            "sha256": "5dda34735d0f14fe7b58f0e4eb10e81b9f030ecce711490c44f114ac3c7908a9"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -14,26 +14,41 @@
         ]
     },
     "default": {
+        "825942b": {
+            "path": "./../arxiv-auth/users"
+        },
+        "amqp": {
+            "hashes": [
+                "sha256:9f181e4aef6562e6f9f45660578fc1556150ca06e836ecb9e733e6ea10b48464",
+                "sha256:c3d7126bfbc640d076a01f1f4f6e609c0e4348508150c1f61336b0d83c738d2b"
+            ],
+            "version": "==2.4.0"
+        },
         "arxiv-auth": {
             "hashes": [
-                "sha256:c391381cc94b83a9173c383b78b06d5a77d5d124d5686577ba8466e68012fd80"
+                "sha256:5e4d2e2155fde458653142613c614fced9f3bc6021d8e3e1c0dd2cd9b0279701"
             ],
-            "index": "pypi",
-            "version": "==0.2.0rc1"
+            "version": "==0.2.5"
         },
         "arxiv-base": {
             "hashes": [
-                "sha256:9896b4f54d4a5e20c5f7ab7e8c65aa022781f8eba149b9730896fe22a44e0535"
+                "sha256:f8fa599e50550e0c6ee9de53030c22c0b8921fca7ac1268753a6b2b0fef177e9"
             ],
             "index": "pypi",
-            "version": "==0.12.1rc2"
+            "version": "==0.12.1"
         },
         "arxiv-submission-core": {
             "hashes": [
-                "sha256:2f314fd6bc6e146485ee5792b03e3315bf126981974ad50ea5685c99c44a6feb"
+                "sha256:b188c3e4852136e773b553b47b2733583acabadde4ee4bda7a77f212c106b325"
             ],
             "index": "pypi",
-            "version": "==0.5.3rc4"
+            "version": "==0.6.1"
+        },
+        "billiard": {
+            "hashes": [
+                "sha256:42d9a227401ac4fba892918bba0a0c409def5435c4b483267ebfe821afaaba0e"
+            ],
+            "version": "==3.5.0.5"
         },
         "bleach": {
             "hashes": [
@@ -45,17 +60,24 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:8f02aebdbb274d1be3af1e6c117865afa97a34a6810a304e079beab5827c7614",
-                "sha256:b131da6494d5036a2768fcea56fb9891bff7eb6b8faaa7dce93e939f50382b1c"
+                "sha256:63cd957ba663f5c10ff48ed904575eaa701314f79f18dbc59bd050311cd5f809",
+                "sha256:d1338582bc58741f54bd6b43488de6097a82ea45cebed0a3fd936981eadbb3a5"
             ],
-            "version": "==1.9.78"
+            "version": "==1.9.86"
         },
         "botocore": {
             "hashes": [
-                "sha256:2cdf5519ddab95774248a002c24fbd804b5e5b44ed1c25497d34b34a06e9f84a",
-                "sha256:bd0b042dded14c7b2978d13dd8088f10f05f9e12382e882e03694e9131185358"
+                "sha256:24444e7580f0114c3e9fff5d2032c6f0cfbf88691b1be3ba27c6922507a902ec",
+                "sha256:5b01a16f02c3da55068b3aacfa1c37dd8e17141551e1702424b38dd21fa1c792"
             ],
-            "version": "==1.12.78"
+            "version": "==1.12.86"
+        },
+        "celery": {
+            "hashes": [
+                "sha256:77ff3730198d6a17b3c1f05579ebe570b579efb35f6d7e13dba3b1368d068b35",
+                "sha256:81a67f0d53a688ec2bc8557bd5d6d7218f925a6f2e6df80e01560de9e28997ec"
+            ],
+            "version": "==4.1.0"
         },
         "certifi": {
             "hashes": [
@@ -138,6 +160,13 @@
             "index": "pypi",
             "version": "==2.6.0"
         },
+        "kombu": {
+            "hashes": [
+                "sha256:01f0da9fe222a2183345004243d1518c0fbe5875955f1b24842f2d9c65709ade",
+                "sha256:4249d9dd9dbf1fcec471d1c2def20653c9310dd1a217272d77e4844f9d5273cb"
+            ],
+            "version": "==4.1.0"
+        },
         "markupsafe": {
             "hashes": [
                 "sha256:048ef924c1623740e70204aa7143ec592504045ae4429b59c30054cb31e3c432",
@@ -173,11 +202,11 @@
         },
         "mysqlclient": {
             "hashes": [
-                "sha256:062d78953acb23066c0387a8f3bd0ecf946626f599145bb7fd201460e8f773e1",
-                "sha256:3981ae9ce545901a36a8b7aed76ed02960a429f75dc53b7ad77fb2f9ab7cd56b",
-                "sha256:b3591a00c0366de71d65108627899710d9cfb00e575c4d211aa8de59b1f130c9"
+                "sha256:6883a4dd98903bad375c859ead1a480e1245ea3a8d9b038ea2c091c1865ba673",
+                "sha256:a62220410e26ce2d2ff94dd0138c3ecfb91db634464a9afb4c8e6b50f0a67e00",
+                "sha256:e1b9f3a8928ddb4985ca3e3c9f2aa81b19e831bbf6fabf5681ee356738dbbbb2"
             ],
-            "version": "==1.3.14"
+            "version": "==1.4.1"
         },
         "pycountry": {
             "hashes": [
@@ -198,7 +227,6 @@
                 "sha256:063df5763652e21de43de7d9e00ccf239f953a832941e37be541614732cdfc93",
                 "sha256:88f9287c0174266bb0d8cedd395cfba9c58e87e5ad86b2ce58859bc11be3cf02"
             ],
-            "markers": "python_version >= '2.7'",
             "version": "==2.7.5"
         },
         "pytz": {
@@ -263,17 +291,23 @@
         },
         "sqlalchemy": {
             "hashes": [
-                "sha256:6af3ca2f7f00844465ab4fa78337d487b39e53f516c51328aed4ed3a719d4264"
+                "sha256:52a42dbf02d0562d6e90e7af59f177f1cc027e72833cc29c3a821eefa009c71d"
             ],
             "index": "pypi",
-            "version": "==1.2.16"
+            "version": "==1.2.17"
+        },
+        "unidecode": {
+            "hashes": [
+                "sha256:092cdf7ad9d1052c50313426a625b717dab52f7ac58f859e09ea020953b1ad8f",
+                "sha256:8b85354be8fd0c0e10adbf0675f6dc2310e56fda43fa8fe049123b6c475e52fb"
+            ],
+            "version": "==1.0.23"
         },
         "urllib3": {
             "hashes": [
                 "sha256:a68ac5e15e76e7e5dd2b8f94007233e01effe3e50e8daddf69acfd81cb686baf",
                 "sha256:b5725a0bd4ba422ab0e66e89e030c806576753ea3ee08554382c14e685d117b5"
             ],
-            "markers": "python_version >= '3.4'",
             "version": "==1.23"
         },
         "uwsgi": {
@@ -282,6 +316,13 @@
             ],
             "index": "pypi",
             "version": "==2.0.17.1"
+        },
+        "vine": {
+            "hashes": [
+                "sha256:3cd505dcf980223cfaf13423d371f2e7ff99247e38d5985a01ec8264e4f2aca1",
+                "sha256:ee4813e915d0e1a54e5c1963fde0855337f82655678540a6bc5996bca4165f76"
+            ],
+            "version": "==1.2.0"
         },
         "webencodings": {
             "hashes": [
@@ -329,13 +370,17 @@
         },
         "coverage": {
             "hashes": [
+                "sha256:06123b58a1410873e22134ca2d88bd36680479fe354955b3579fb8ff150e4d27",
                 "sha256:09e47c529ff77bf042ecfe858fb55c3e3eb97aac2c87f0349ab5a7efd6b3939f",
                 "sha256:0a1f9b0eb3aa15c990c328535655847b3420231af299386cfe5efc98f9c250fe",
                 "sha256:0cc941b37b8c2ececfed341444a456912e740ecf515d560de58b9a76562d966d",
+                "sha256:0d34245f824cc3140150ab7848d08b7e2ba67ada959d77619c986f2062e1f0e8",
                 "sha256:10e8af18d1315de936d67775d3a814cc81d0747a1a0312d84e27ae5610e313b0",
                 "sha256:1b4276550b86caa60606bd3572b52769860a81a70754a54acc8ba789ce74d607",
                 "sha256:1e8a2627c48266c7b813975335cfdea58c706fe36f607c97d9392e61502dc79d",
+                "sha256:258b21c5cafb0c3768861a6df3ab0cfb4d8b495eee5ec660e16f928bf7385390",
                 "sha256:2b224052bfd801beb7478b03e8a66f3f25ea56ea488922e98903914ac9ac930b",
+                "sha256:3ad59c84c502cd134b0088ca9038d100e8fb5081bbd5ccca4863f3804d81f61d",
                 "sha256:447c450a093766744ab53bf1e7063ec82866f27bcb4f4c907da25ad293bba7e3",
                 "sha256:46101fc20c6f6568561cdd15a54018bb42980954b79aa46da8ae6f008066a30e",
                 "sha256:4710dc676bb4b779c4361b54eb308bc84d64a2fa3d78e5f7228921eccce5d815",
@@ -345,10 +390,16 @@
                 "sha256:5f55028169ef85e1fa8e4b8b1b91c0b3b0fa3297c4fb22990d46ff01d22c2d6c",
                 "sha256:6694d5573e7790a0e8d3d177d7a416ca5f5c150742ee703f3c18df76260de794",
                 "sha256:6831e1ac20ac52634da606b658b0b2712d26984999c9d93f0c6e59fe62ca741b",
+                "sha256:71afc1f5cd72ab97330126b566bbf4e8661aab7449f08895d21a5d08c6b051ff",
+                "sha256:7349c27128334f787ae63ab49d90bf6d47c7288c63a0a5dfaa319d4b4541dd2c",
                 "sha256:77f0d9fa5e10d03aa4528436e33423bfa3718b86c646615f04616294c935f840",
                 "sha256:828ad813c7cdc2e71dcf141912c685bfe4b548c0e6d9540db6418b807c345ddd",
+                "sha256:859714036274a75e6e57c7bab0c47a4602d2a8cfaaa33bbdb68c8359b2ed4f5c",
                 "sha256:85a06c61598b14b015d4df233d249cd5abfa61084ef5b9f64a48e997fd829a82",
+                "sha256:869ef4a19f6e4c6987e18b315721b8b971f7048e6eaea29c066854242b4e98d9",
                 "sha256:8cb4febad0f0b26c6f62e1628f2053954ad2c555d67660f28dfb1b0496711952",
+                "sha256:977e2d9a646773cc7428cdd9a34b069d6ee254fadfb4d09b3f430e95472f3cf3",
+                "sha256:99bd767c49c775b79fdcd2eabff405f1063d9d959039c0bdd720527a7738748a",
                 "sha256:a5c58664b23b248b16b96253880b2868fb34358911400a7ba39d7f6399935389",
                 "sha256:aaa0f296e503cda4bc07566f592cd7a28779d433f3a23c48082af425d6d5a78f",
                 "sha256:ab235d9fe64833f12d1334d29b558aacedfbca2356dfb9691f2d0d38a8a7bfb4",
@@ -444,11 +495,11 @@
         },
         "mypy": {
             "hashes": [
-                "sha256:12d965c9c4e8a625673aec493162cf390e66de12ef176b1f4821ac00d55f3ab3",
-                "sha256:38d5b5f835a81817dcc0af8d155bce4e9aefa03794fe32ed154d6612e83feafa"
+                "sha256:986a7f97808a865405c5fd98fae5ebfa963c31520a56c783df159e9a81e41b3e",
+                "sha256:cc5df73cc11d35655a8c364f45d07b13c8db82c000def4bd7721be13356533b4"
             ],
             "index": "pypi",
-            "version": "==0.650"
+            "version": "==0.660"
         },
         "mypy-extensions": {
             "hashes": [
@@ -505,44 +556,43 @@
         },
         "typed-ast": {
             "hashes": [
-                "sha256:0555eca1671ebe09eb5f2176723826f6f44cca5060502fea259de9b0e893ab53",
-                "sha256:0ca96128ea66163aea13911c9b4b661cb345eb729a20be15c034271360fc7474",
-                "sha256:16ccd06d614cf81b96de42a37679af12526ea25a208bce3da2d9226f44563868",
-                "sha256:1e21ae7b49a3f744958ffad1737dfbdb43e1137503ccc59f4e32c4ac33b0bd1c",
-                "sha256:37670c6fd857b5eb68aa5d193e14098354783b5138de482afa401cc2644f5a7f",
-                "sha256:46d84c8e3806619ece595aaf4f37743083f9454c9ea68a517f1daa05126daf1d",
-                "sha256:5b972bbb3819ece283a67358103cc6671da3646397b06e7acea558444daf54b2",
-                "sha256:6306ffa64922a7b58ee2e8d6f207813460ca5a90213b4a400c2e730375049246",
-                "sha256:6cb25dc95078931ecbd6cbcc4178d1b8ae8f2b513ae9c3bd0b7f81c2191db4c6",
-                "sha256:7e19d439fee23620dea6468d85bfe529b873dace39b7e5b0c82c7099681f8a22",
-                "sha256:7f5cd83af6b3ca9757e1127d852f497d11c7b09b4716c355acfbebf783d028da",
-                "sha256:81e885a713e06faeef37223a5b1167615db87f947ecc73f815b9d1bbd6b585be",
-                "sha256:94af325c9fe354019a29f9016277c547ad5d8a2d98a02806f27a7436b2da6735",
-                "sha256:b1e5445c6075f509d5764b84ce641a1535748801253b97f3b7ea9d948a22853a",
-                "sha256:cb061a959fec9a514d243831c514b51ccb940b58a5ce572a4e209810f2507dcf",
-                "sha256:cc8d0b703d573cbabe0d51c9d68ab68df42a81409e4ed6af45a04a95484b96a5",
-                "sha256:da0afa955865920edb146926455ec49da20965389982f91e926389666f5cf86a",
-                "sha256:dc76738331d61818ce0b90647aedde17bbba3d3f9e969d83c1d9087b4f978862",
-                "sha256:e7ec9a1445d27dbd0446568035f7106fa899a36f55e52ade28020f7b3845180d",
-                "sha256:f741ba03feb480061ab91a465d1a3ed2d40b52822ada5b4017770dfcb88f839f",
-                "sha256:fe800a58547dd424cd286b7270b967b5b3316b993d86453ede184a17b5a6b17d"
+                "sha256:023625bfa9359e29bd6e24cac2a4503495b49761d48a5f1e38333fc4ac4d93fe",
+                "sha256:07591f7a5fdff50e2e566c4c1e9df545c75d21e27d98d18cb405727ed0ef329c",
+                "sha256:153e526b0f4ffbfada72d0bb5ffe8574ba02803d2f3a9c605c8cf99dfedd72a2",
+                "sha256:3ad2bdcd46a4a1518d7376e9f5016d17718a9ed3c6a3f09203d832f6c165de4a",
+                "sha256:3ea98c84df53ada97ee1c5159bb3bc784bd734231235a1ede14c8ae0775049f7",
+                "sha256:51a7141ccd076fa561af107cfb7a8b6d06a008d92451a1ac7e73149d18e9a827",
+                "sha256:52c93cd10e6c24e7ac97e8615da9f224fd75c61770515cb323316c30830ddb33",
+                "sha256:6344c84baeda3d7b33e157f0b292e4dd53d05ddb57a63f738178c01cac4635c9",
+                "sha256:64699ca1b3bd5070bdeb043e6d43bc1d0cebe08008548f4a6bee782b0ecce032",
+                "sha256:74903f2e56bbffe29282ef8a5487d207d10be0f8513b41aff787d954a4cf91c9",
+                "sha256:7891710dba83c29ee2bd51ecaa82f60f6bede40271af781110c08be134207bf2",
+                "sha256:91976c56224e26c256a0de0f76d2004ab885a29423737684b4f7ebdd2f46dde2",
+                "sha256:9bad678a576ecc71f25eba9f1e3fd8d01c28c12a2834850b458428b3e855f062",
+                "sha256:b4726339a4c180a8b6ad9d8b50d2b6dc247e1b79b38fe2290549c98e82e4fd15",
+                "sha256:ba36f6aa3f8933edf94ea35826daf92cbb3ec248b89eccdc053d4a815d285357",
+                "sha256:bbc96bde544fd19e9ef168e4dfa5c3dfe704bfa78128fa76f361d64d6b0f731a",
+                "sha256:c0c927f1e44469056f7f2dada266c79b577da378bbde3f6d2ada726d131e4824",
+                "sha256:c0f9a3708008aa59f560fa1bd22385e05b79b8e38e0721a15a8402b089243442",
+                "sha256:f0bf6f36ff9c5643004171f11d2fdc745aa3953c5aacf2536a0685db9ceb3fb1",
+                "sha256:f5be39a0146be663cbf210a4d95c3c58b2d7df7b043c9047c5448e358f0550a2",
+                "sha256:fcd198bf19d9213e5cbf2cde2b9ef20a9856e716f76f9476157f90ae6de06cc6"
             ],
             "markers": "python_version < '3.7' and implementation_name == 'cpython'",
-            "version": "==1.1.1"
+            "version": "==1.2.0"
         },
         "urllib3": {
             "hashes": [
                 "sha256:a68ac5e15e76e7e5dd2b8f94007233e01effe3e50e8daddf69acfd81cb686baf",
                 "sha256:b5725a0bd4ba422ab0e66e89e030c806576753ea3ee08554382c14e685d117b5"
             ],
-            "markers": "python_version >= '3.4'",
             "version": "==1.23"
         },
         "wrapt": {
             "hashes": [
-                "sha256:e03f19f64d81d0a3099518ca26b04550026f131eced2e76ced7b85c6b8d32128"
+                "sha256:4aea003270831cceb8a90ff27c4031da6ead7ec1886023b80ce0dfe0adf61533"
             ],
-            "version": "==1.11.0"
+            "version": "==1.11.1"
         }
     }
 }

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "b81e71c76abd07fef345161f5850366f6b4adad75e42548d369de6624a7f0a4f"
+            "sha256": "0c8eefa91cae91790e515f5908a1f84c5b7fbfc4bb7380fb2001d1c333555084"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -37,10 +37,10 @@
         },
         "arxiv-submission-core": {
             "hashes": [
-                "sha256:f7d21d2ab23d8ea1771f029c26a79eb1c0c4a1d9384fd14cbcfc0e54eac9de03"
+                "sha256:ab98b9c4ed999189e8b867b9fb8a7c579381c20d717c3cb0d07ef73dcac5dc60"
             ],
             "index": "pypi",
-            "version": "==0.6.2rc1"
+            "version": "==0.6.2rc2"
         },
         "billiard": {
             "hashes": [
@@ -577,6 +577,7 @@
                 "sha256:f5be39a0146be663cbf210a4d95c3c58b2d7df7b043c9047c5448e358f0550a2",
                 "sha256:fcd198bf19d9213e5cbf2cde2b9ef20a9856e716f76f9476157f90ae6de06cc6"
             ],
+            "markers": "python_version < '3.7' and implementation_name == 'cpython'",
             "version": "==1.2.0"
         },
         "urllib3": {

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ session = domain.Session(
             affiliation="FSU",
             rank=3,
             country="de",
-            default_category=domain.Category('astro-ph', 'GA'),
+            default_category=domain.Category('astro-ph.GA'),
             submission_groups=['grp_physics']
         )
     ),
@@ -90,8 +90,8 @@ session = domain.Session(
         scopes=[auth.scopes.CREATE_SUBMISSION,
                 auth.scopes.EDIT_SUBMISSION,
                 auth.scopes.VIEW_SUBMISSION],
-        endorsements=[domain.Category('astro-ph', 'CO'),
-                      domain.Category('astro-ph', 'GA')]
+        endorsements=[domain.Category('astro-ph.CO'),
+                      domain.Category('astro-ph.GA')]
     )
 )
 secret = 'foosecret'    # Note this secret. 

--- a/submit/controllers/classification.py
+++ b/submit/controllers/classification.py
@@ -59,8 +59,9 @@ class ClassificationForm(csrf.CSRFForm):
             (archive, [
                 (category, display) for category, display in archive_choices
                 if session.authorizations.endorsed_for(category)
-                and (primary is None or category != primary.category)
-                and category not in submission.secondary_categories
+                and (((primary is None or category != primary.category)
+                      and category not in submission.secondary_categories)
+                     or category == selected)
             ])
             for archive, archive_choices in self.category.choices
         ]

--- a/submit/controllers/classification.py
+++ b/submit/controllers/classification.py
@@ -107,7 +107,7 @@ def classification(method: str, params: MultiDict, session: Session,
     if method == 'GET':
         params = _data_from_submission(params, submission)
         if 'category' not in params:
-            params['category'] = session.user.profile.default_category.compound
+            params['category'] = session.user.profile.default_category
 
     params['operation'] = ClassificationForm.ADD     # Always add a primary.
 

--- a/submit/controllers/create.py
+++ b/submit/controllers/create.py
@@ -25,7 +25,7 @@ class CreateSubmissionForm(csrf.CSRFForm):
 def create(method: str, params: MultiDict, session: Session) -> Response:
     """Create a new submission, and redirect to workflow."""
     if method == 'GET':     # Display a splash page.
-        submissions = events.load_submissions_for_user(session.user.user_id)
+        submissions = events.core.load_submissions_for_user(session.user.user_id)
 
         response_data = {
             'form': CreateSubmissionForm(),

--- a/submit/controllers/tests/test_authorship.py
+++ b/submit/controllers/tests/test_authorship.py
@@ -33,7 +33,7 @@ class TestVerifyAuthorship(TestCase):
                     affiliation="FSU",
                     rank=3,
                     country="de",
-                    default_category=domain.Category('astro-ph', 'GA'),
+                    default_category=domain.Category('astro-ph.GA'),
                     submission_groups=['grp_physics']
                 )
             ),
@@ -41,8 +41,8 @@ class TestVerifyAuthorship(TestCase):
                 scopes=[auth.scopes.CREATE_SUBMISSION,
                         auth.scopes.EDIT_SUBMISSION,
                         auth.scopes.VIEW_SUBMISSION],
-                endorsements=[domain.Category('astro-ph', 'CO'),
-                              domain.Category('astro-ph', 'GA')]
+                endorsements=[domain.Category('astro-ph.CO'),
+                              domain.Category('astro-ph.GA')]
             )
         )
 

--- a/submit/controllers/tests/test_classification.py
+++ b/submit/controllers/tests/test_classification.py
@@ -33,7 +33,7 @@ class TestClassification(TestCase):
                     affiliation="FSU",
                     rank=3,
                     country="de",
-                    default_category=domain.Category('astro-ph', 'GA'),
+                    default_category=domain.Category('astro-ph.GA'),
                     submission_groups=['grp_physics']
                 )
             ),
@@ -41,8 +41,8 @@ class TestClassification(TestCase):
                 scopes=[auth.scopes.CREATE_SUBMISSION,
                         auth.scopes.EDIT_SUBMISSION,
                         auth.scopes.VIEW_SUBMISSION],
-                endorsements=[domain.Category('astro-ph', 'CO'),
-                              domain.Category('astro-ph', 'GA')]
+                endorsements=[domain.Category('astro-ph.CO'),
+                              domain.Category('astro-ph.GA')]
             )
         )
 
@@ -174,7 +174,7 @@ class TestCrossList(TestCase):
                     affiliation="FSU",
                     rank=3,
                     country="de",
-                    default_category=domain.Category('astro-ph', 'GA'),
+                    default_category=domain.Category('astro-ph.GA'),
                     submission_groups=['grp_physics']
                 )
             ),
@@ -182,8 +182,8 @@ class TestCrossList(TestCase):
                 scopes=[auth.scopes.CREATE_SUBMISSION,
                         auth.scopes.EDIT_SUBMISSION,
                         auth.scopes.VIEW_SUBMISSION],
-                endorsements=[domain.Category('astro-ph', 'CO'),
-                              domain.Category('astro-ph', 'GA')]
+                endorsements=[domain.Category('astro-ph.CO'),
+                              domain.Category('astro-ph.GA')]
             )
         )
 

--- a/submit/controllers/tests/test_jref.py
+++ b/submit/controllers/tests/test_jref.py
@@ -39,7 +39,7 @@ class TestJREFSubmission(TestCase):
                     affiliation="FSU",
                     rank=3,
                     country="de",
-                    default_category=domain.Category('astro-ph', 'GA'),
+                    default_category=domain.Category('astro-ph.GA'),
                     submission_groups=['grp_physics']
                 )
             ),
@@ -47,8 +47,8 @@ class TestJREFSubmission(TestCase):
                 scopes=[auth.scopes.CREATE_SUBMISSION,
                         auth.scopes.EDIT_SUBMISSION,
                         auth.scopes.VIEW_SUBMISSION],
-                endorsements=[domain.Category('astro-ph', 'CO'),
-                              domain.Category('astro-ph', 'GA')]
+                endorsements=[domain.Category('astro-ph.CO'),
+                              domain.Category('astro-ph.GA')]
             )
         )
 

--- a/submit/controllers/tests/test_license.py
+++ b/submit/controllers/tests/test_license.py
@@ -34,7 +34,7 @@ class TestSetLicense(TestCase):
                     affiliation="FSU",
                     rank=3,
                     country="de",
-                    default_category=domain.Category('astro-ph', 'GA'),
+                    default_category=domain.Category('astro-ph.GA'),
                     submission_groups=['grp_physics']
                 )
             ),
@@ -42,8 +42,8 @@ class TestSetLicense(TestCase):
                 scopes=[auth.scopes.CREATE_SUBMISSION,
                         auth.scopes.EDIT_SUBMISSION,
                         auth.scopes.VIEW_SUBMISSION],
-                endorsements=[domain.Category('astro-ph', 'CO'),
-                              domain.Category('astro-ph', 'GA')]
+                endorsements=[domain.Category('astro-ph.CO'),
+                              domain.Category('astro-ph.GA')]
             )
         )
 

--- a/submit/controllers/tests/test_metadata.py
+++ b/submit/controllers/tests/test_metadata.py
@@ -33,7 +33,7 @@ class TestOptional(TestCase):
                     affiliation="FSU",
                     rank=3,
                     country="de",
-                    default_category=domain.Category('astro-ph', 'GA'),
+                    default_category=domain.Category('astro-ph.GA'),
                     submission_groups=['grp_physics']
                 )
             ),
@@ -41,8 +41,8 @@ class TestOptional(TestCase):
                 scopes=[auth.scopes.CREATE_SUBMISSION,
                         auth.scopes.EDIT_SUBMISSION,
                         auth.scopes.VIEW_SUBMISSION],
-                endorsements=[domain.Category('astro-ph', 'CO'),
-                              domain.Category('astro-ph', 'GA')]
+                endorsements=[domain.Category('astro-ph.CO'),
+                              domain.Category('astro-ph.GA')]
             )
         )
 
@@ -255,7 +255,7 @@ class TestMetadata(TestCase):
                     affiliation="FSU",
                     rank=3,
                     country="de",
-                    default_category=domain.Category('astro-ph', 'GA'),
+                    default_category=domain.Category('astro-ph.GA'),
                     submission_groups=['grp_physics']
                 )
             ),
@@ -263,8 +263,8 @@ class TestMetadata(TestCase):
                 scopes=[auth.scopes.CREATE_SUBMISSION,
                         auth.scopes.EDIT_SUBMISSION,
                         auth.scopes.VIEW_SUBMISSION],
-                endorsements=[domain.Category('astro-ph', 'CO'),
-                              domain.Category('astro-ph', 'GA')]
+                endorsements=[domain.Category('astro-ph.CO'),
+                              domain.Category('astro-ph.GA')]
             )
         )
 

--- a/submit/controllers/tests/test_policy.py
+++ b/submit/controllers/tests/test_policy.py
@@ -33,7 +33,7 @@ class TestConfirmPolicy(TestCase):
                     affiliation="FSU",
                     rank=3,
                     country="de",
-                    default_category=domain.Category('astro-ph', 'GA'),
+                    default_category=domain.Category('astro-ph.GA'),
                     submission_groups=['grp_physics']
                 )
             ),
@@ -41,8 +41,8 @@ class TestConfirmPolicy(TestCase):
                 scopes=[auth.scopes.CREATE_SUBMISSION,
                         auth.scopes.EDIT_SUBMISSION,
                         auth.scopes.VIEW_SUBMISSION],
-                endorsements=[domain.Category('astro-ph', 'CO'),
-                              domain.Category('astro-ph', 'GA')]
+                endorsements=[domain.Category('astro-ph.CO'),
+                              domain.Category('astro-ph.GA')]
             )
         )
 

--- a/submit/controllers/tests/test_primary.py
+++ b/submit/controllers/tests/test_primary.py
@@ -33,7 +33,7 @@ class TestSetPrimaryClassification(TestCase):
                     affiliation="FSU",
                     rank=3,
                     country="de",
-                    default_category=domain.Category('astro-ph', 'GA'),
+                    default_category=domain.Category('astro-ph.GA'),
                     submission_groups=['grp_physics']
                 )
             ),
@@ -41,8 +41,8 @@ class TestSetPrimaryClassification(TestCase):
                 scopes=[auth.scopes.CREATE_SUBMISSION,
                         auth.scopes.EDIT_SUBMISSION,
                         auth.scopes.VIEW_SUBMISSION],
-                endorsements=[domain.Category('astro-ph', 'CO'),
-                              domain.Category('astro-ph', 'GA')]
+                endorsements=[domain.Category('astro-ph.CO'),
+                              domain.Category('astro-ph.GA')]
             )
         )
 

--- a/submit/controllers/tests/test_primary.py
+++ b/submit/controllers/tests/test_primary.py
@@ -114,9 +114,11 @@ class TestSetPrimaryClassification(TestCase):
         redirect_url = 'https://foo.bar.com/yes'
         mock_url_for.return_value = redirect_url
 
-        form_data = MultiDict({'category': 'astro-ph.EP',
+        form_data = MultiDict({'category': 'astro-ph.CO',
                                'action': 'next'})
-        data, code, headers = classification.classification('POST', form_data, self.session, submission_id)
+        data, code, headers = classification.classification(
+            'POST', form_data, self.session, submission_id
+        )
         self.assertEqual(code, status.HTTP_303_SEE_OTHER,
                          "Returns 303 redirect")
 
@@ -146,7 +148,7 @@ class TestSetPrimaryClassification(TestCase):
             )
 
         mock_save.side_effect = raise_on_set
-        form_data = MultiDict({'category': 'astro-ph.EP',
+        form_data = MultiDict({'category': 'astro-ph.CO',
                                'action': 'next'})
         data, code, headers = classification.classification('POST', form_data, self.session, 2)
         self.assertEqual(code, status.HTTP_400_BAD_REQUEST,

--- a/submit/controllers/tests/test_upload.py
+++ b/submit/controllers/tests/test_upload.py
@@ -36,7 +36,7 @@ class TestUpload(TestCase):
                     affiliation='FSU',
                     rank=3,
                     country='de',
-                    default_category=domain.Category('astro-ph', 'GA'),
+                    default_category=domain.Category('astro-ph.GA'),
                     submission_groups=['grp_physics']
                 )
             ),
@@ -44,8 +44,8 @@ class TestUpload(TestCase):
                 scopes=[auth.scopes.CREATE_SUBMISSION,
                         auth.scopes.EDIT_SUBMISSION,
                         auth.scopes.VIEW_SUBMISSION],
-                endorsements=[domain.Category('astro-ph', 'CO'),
-                              domain.Category('astro-ph', 'GA')]
+                endorsements=[domain.Category('astro-ph.CO'),
+                              domain.Category('astro-ph.GA')]
             )
         )
 
@@ -200,7 +200,7 @@ class TestDelete(TestCase):
                     affiliation='FSU',
                     rank=3,
                     country='de',
-                    default_category=domain.Category('astro-ph', 'GA'),
+                    default_category=domain.Category('astro-ph.GA'),
                     submission_groups=['grp_physics']
                 )
             ),
@@ -208,8 +208,8 @@ class TestDelete(TestCase):
                 scopes=[auth.scopes.CREATE_SUBMISSION,
                         auth.scopes.EDIT_SUBMISSION,
                         auth.scopes.VIEW_SUBMISSION],
-                endorsements=[domain.Category('astro-ph', 'CO'),
-                              domain.Category('astro-ph', 'GA')]
+                endorsements=[domain.Category('astro-ph.CO'),
+                              domain.Category('astro-ph.GA')]
             )
         )
 

--- a/submit/controllers/tests/test_verify_user.py
+++ b/submit/controllers/tests/test_verify_user.py
@@ -33,7 +33,7 @@ class TestVerifyUser(TestCase):
                     affiliation="FSU",
                     rank=3,
                     country="de",
-                    default_category=domain.Category('astro-ph', 'GA'),
+                    default_category=domain.Category('astro-ph.GA'),
                     submission_groups=['grp_physics']
                 )
             ),
@@ -41,8 +41,8 @@ class TestVerifyUser(TestCase):
                 scopes=[auth.scopes.CREATE_SUBMISSION,
                         auth.scopes.EDIT_SUBMISSION,
                         auth.scopes.VIEW_SUBMISSION],
-                endorsements=[domain.Category('astro-ph', 'CO'),
-                              domain.Category('astro-ph', 'GA')]
+                endorsements=[domain.Category('astro-ph.CO'),
+                              domain.Category('astro-ph.GA')]
             )
         )
 

--- a/submit/controllers/util.py
+++ b/submit/controllers/util.py
@@ -179,6 +179,6 @@ def user_and_client_from_session(session: Session) \
         forename=getattr(session.user.name, 'forename', None),
         surname=getattr(session.user.name, 'surname', None),
         suffix=getattr(session.user.name, 'suffix', None),
-        endorsements=[c.compound for c in session.authorizations.endorsements]
+        endorsements=session.authorizations.endorsements
     )
     return user, None

--- a/submit/domain.py
+++ b/submit/domain.py
@@ -94,10 +94,12 @@ class StageBase(NamedTuple):
         """Determine whether the submitter has uploaded files."""
         return submission.source_content is not None
 
+    # TODO: this needs a bit more work, since the compilation may have failed
+    # or may not be complete for the current state of the upload workspace.
     @staticmethod
     def files_are_processed(submission: Submission) -> bool:
         """Determine whether the submitter has compiled their upload."""
-        return len(submission.compiled_content) > 0
+        return len(submission.compilations) > 0
 
     @staticmethod
     def metadata_is_set(submission: Submission) -> bool:

--- a/submit/routes/ui.py
+++ b/submit/routes/ui.py
@@ -609,11 +609,9 @@ def endorsetype(endorsements: List[str]) -> str:
     str
         For now.
     """
-    if(len(endorsements) == 0):
+    if len(endorsements) == 0:
         return 'None'
-    elif(len(taxonomy.CATEGORIES_ACTIVE.keys()) - len(endorsements) == 0):
+    elif '*.*' in endorsements:
         return 'All'
-    elif(len(taxonomy.CATEGORIES_ACTIVE.keys()) - len(endorsements) > 0):
-        return 'Some'
     else:
-        return 'Error'
+        return 'Some'

--- a/submit/templates/submit/classification.html
+++ b/submit/templates/submit/classification.html
@@ -39,11 +39,17 @@
 
     <div class="column is-one-third-tablet is-half-desktop">
       {% if submitter.endorsements|endorsetype == 'None' %}
-        <div class="message is-link">
-          <div class="message-body">
-            <p>No list options means no endorsement. It should be impossible to get to this page without endorsement, but if one does, show an appropriate message.</p>
-          </div>
+      <div class="message is-danger">
+        <div class="message-header">
+          <p>Endorsements</p>
         </div>
+        <div class="message-body">
+          <div class="is-pulled-left">
+            <span class="icon"><i class="fa fa-exclamation-triangle"></i></span>
+          </div>
+          <p>Your account does not currently have any endorsed categories. You will need to <a href="{{ url_for('help_endorse') }}">seek endorsement</a> before submitting.</p>
+        </div>
+      </div>
       {% endif %}
       {% if submitter.endorsements|endorsetype == 'Some' %}
         <div class="message is-link">

--- a/submit/templates/submit/verify_user.html
+++ b/submit/templates/submit/verify_user.html
@@ -61,7 +61,7 @@
           <p>You are currently endorsed for: </p>
           <ul>
           {% for endorsement in submitter.endorsements %}
-            <li>{{ endorsement }}</li>
+            <li>{{ endorsement.display }}</li>
           {% endfor %}
           </ul>
           <p>If you wish to submit to a category other than those listed, you will need to <a href="{{ url_for('help_endorse') }}">seek endorsement</a> before submitting.</p>

--- a/submit/tests/test_workflow.py
+++ b/submit/tests/test_workflow.py
@@ -43,8 +43,8 @@ class TestSubmissionWorkflow(TestCase):
                                            scopes.WRITE_UPLOAD,
                                            scopes.DELETE_UPLOAD_FILE],
                                     endorsements=[
-                                        Category('astro-ph', 'GA'),
-                                        Category('astro-ph', 'CO'),
+                                        Category('astro-ph.GA'),
+                                        Category('astro-ph.CO'),
                                     ])
         self.headers = {'Authorization': self.token}
         self.client = self.app.test_client()
@@ -205,8 +205,8 @@ class TestJREFWorkflow(TestCase):
                                            scopes.WRITE_UPLOAD,
                                            scopes.DELETE_UPLOAD_FILE],
                                     endorsements=[
-                                        Category('astro-ph', 'GA'),
-                                        Category('astro-ph', 'CO'),
+                                        Category('astro-ph.GA'),
+                                        Category('astro-ph.CO'),
                                     ])
         self.headers = {'Authorization': self.token}
         self.client = self.app.test_client()
@@ -333,8 +333,8 @@ class TestWithdrawalWorkflow(TestCase):
                                            scopes.WRITE_UPLOAD,
                                            scopes.DELETE_UPLOAD_FILE],
                                     endorsements=[
-                                        Category('astro-ph', 'GA'),
-                                        Category('astro-ph', 'CO'),
+                                        Category('astro-ph.GA'),
+                                        Category('astro-ph.CO'),
                                     ])
         self.headers = {'Authorization': self.token}
         self.client = self.app.test_client()


### PR DESCRIPTION
This leverages https://github.com/arXiv/arxiv-auth/pull/30 (ARXIVNG-1468) to display the submitter's  endorsement status more coherently on the verify user page. 

Note that https://github.com/arXiv/arxiv-auth/blob/develop/generate_token.py can be used to generate auth tokens with different endorsement authorizations.

No endorsements:
![image](https://user-images.githubusercontent.com/3451594/52066389-72794780-2546-11e9-8c63-fe1c3d586be9.png)

Some endorsed categories:
``astro-ph.CO,astro-ph.GA``
![image](https://user-images.githubusercontent.com/3451594/52066471-a5234000-2546-11e9-82e2-62e938058239.png)

Endorsed for entire archives (all categories in an archive):
``hep-ph.*,nucl-th.*,math-ph.*,physics.*,q-bio.*,nlin.*,hep-th.*``
![image](https://user-images.githubusercontent.com/3451594/52066538-c4ba6880-2546-11e9-9bb9-d924be9f99e2.png)
*note that the ``.*`` after the archive keys is removed in https://github.com/arXiv/arxiv-base/pull/92*

Endorsed for everything (``*.*``):
![image](https://user-images.githubusercontent.com/3451594/52066688-077c4080-2547-11e9-95ce-f328532efd41.png)
