### PR TITLE
ARXIVNG-1804 ability to cancel withdrawal and cross-list requests

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -18,10 +18,10 @@ arxiv-base = "==0.15.3rc7"
 mypy_extensions = "*"
 arxiv-auth = "==0.3.2rc6"
 mysqlclient = "==1.4.2"
-arxiv-submission-core = "==0.6.2rc27"
 mimesis = "==2.1.0"
 backports-datetime-fromisoformat = "*"
 flask-session = "*"
+arxiv-submission-core = {path = "./../arxiv-submission-core/core"}
 
 [dev-packages]
 pydocstyle = "*"

--- a/Pipfile
+++ b/Pipfile
@@ -21,7 +21,7 @@ mysqlclient = "==1.4.2"
 mimesis = "==2.1.0"
 backports-datetime-fromisoformat = "*"
 flask-session = "*"
-arxiv-submission-core = {path = "./../arxiv-submission-core/core"}
+arxiv-submission-core = "==0.7.1rc4"
 
 [dev-packages]
 pydocstyle = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "f5ace6eec2b4050880a21dfddd5daef9c5694080b6583e997d29c6d083d139a5"
+            "sha256": "996f32af7d739acce93451f719734436a1d3c129980cc67ef3e7df2b1e1e01be"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -14,13 +14,6 @@
         ]
     },
     "default": {
-        "amqp": {
-            "hashes": [
-                "sha256:043beb485774ca69718a35602089e524f87168268f0d1ae115f28b88d27f92d7",
-                "sha256:35a3b5006ca00b21aaeec8ceea07130f07b902dd61bfe42815039835f962f5f1"
-            ],
-            "version": "==2.4.2"
-        },
         "arxiv-auth": {
             "hashes": [
                 "sha256:440b3f18a9cc0ce36fbffd5d6f565c33215f118619bc2c3f35f1c1adad74dad8"
@@ -34,13 +27,6 @@
             ],
             "index": "pypi",
             "version": "==0.15.3rc7"
-        },
-        "arxiv-submission-core": {
-            "hashes": [
-                "sha256:322c4a7722034ccb56019d110e36d482c24f234e9105568d00dfd522fcf93e42"
-            ],
-            "index": "pypi",
-            "version": "==0.6.2rc27"
         },
         "attrs": {
             "hashes": [
@@ -56,12 +42,6 @@
             "index": "pypi",
             "version": "==1.0.0"
         },
-        "billiard": {
-            "hashes": [
-                "sha256:42d9a227401ac4fba892918bba0a0c409def5435c4b483267ebfe821afaaba0e"
-            ],
-            "version": "==3.5.0.5"
-        },
         "bleach": {
             "hashes": [
                 "sha256:213336e49e102af26d9cde77dd2d0397afabc5a6bf2fed985dc35b5d1e285a16",
@@ -72,24 +52,17 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:69aac64100a8680db98c327af969af40f2241ba7a72ef271bff106e49c9be848",
-                "sha256:dcf46a30d33ee213acfd3f7d61f60a1797dc21b8e3f8121ebe9eeb00237fea61"
+                "sha256:80f24c01a630e6be409d70aa1b1e30076eda1daf8456157ec210aea2d8d51f2c",
+                "sha256:f259046902b1daa542a08f08796d000160e9801a87f470faf940addacedcc7d7"
             ],
-            "version": "==1.9.116"
+            "version": "==1.9.117"
         },
         "botocore": {
             "hashes": [
-                "sha256:724008bddb35e0833a44613b67bc3c6af3ca07e3f661a55cb3861ccf06bccfb8",
-                "sha256:b0e79b61dda7fb5f05949a4fe319d44108e0ba6db41775d909b891e6992d5a06"
+                "sha256:6c3b1b3344d7bb53a85d3877047e5f29a46f13deb27bda2e85a6d24d7a27c5bf",
+                "sha256:c2a8ae81bb2dfd70951279a1b63ba7ef89333675f9ff479b008ce14fcd9872c1"
             ],
-            "version": "==1.12.116"
-        },
-        "celery": {
-            "hashes": [
-                "sha256:77ff3730198d6a17b3c1f05579ebe570b579efb35f6d7e13dba3b1368d068b35",
-                "sha256:81a67f0d53a688ec2bc8557bd5d6d7218f925a6f2e6df80e01560de9e28997ec"
-            ],
-            "version": "==4.1.0"
+            "version": "==1.12.117"
         },
         "certifi": {
             "hashes": [
@@ -120,13 +93,6 @@
             "index": "pypi",
             "version": "==0.6"
         },
-        "decorator": {
-            "hashes": [
-                "sha256:86156361c50488b84a3f148056ea716ca587df2f0de1d34750d35c21312725de",
-                "sha256:f069f3a01830ca754ba5258fde2278454a0b5b79e0d7f5c13b3b97e57d4acff6"
-            ],
-            "version": "==4.4.0"
-        },
         "docutils": {
             "hashes": [
                 "sha256:02aec4bd92ab067f6ff27a38a38a41173bf01bed8f89157768c1573f53e474a6",
@@ -150,13 +116,6 @@
             ],
             "index": "pypi",
             "version": "==0.3.1"
-        },
-        "flask-sqlalchemy": {
-            "hashes": [
-                "sha256:3bc0fac969dd8c0ace01b32060f0c729565293302f0c4269beed154b46bec50b",
-                "sha256:5971b9852b5888655f11db634e87725a9031e170f37c0ce7851cf83497f56e53"
-            ],
-            "version": "==2.3.2"
         },
         "idna": {
             "hashes": [
@@ -193,13 +152,6 @@
             ],
             "index": "pypi",
             "version": "==3.0.1"
-        },
-        "kombu": {
-            "hashes": [
-                "sha256:01f0da9fe222a2183345004243d1518c0fbe5875955f1b24842f2d9c65709ade",
-                "sha256:4249d9dd9dbf1fcec471d1c2def20653c9310dd1a217272d77e4844f9d5273cb"
-            ],
-            "version": "==4.1.0"
         },
         "markupsafe": {
             "hashes": [
@@ -257,13 +209,6 @@
             "index": "pypi",
             "version": "==1.4.2"
         },
-        "py": {
-            "hashes": [
-                "sha256:64f65755aee5b381cea27766a3a147c3f15b9b6b9ac88676de66ba2ae36793fa",
-                "sha256:dc639b046a6e2cff5bbe40194ad65936d6ba360b52b3c3fe1d08a82dd50b5e53"
-            ],
-            "version": "==1.8.0"
-        },
         "pycountry": {
             "hashes": [
                 "sha256:104a8ca94c700898c42a0172da2eab5a5675c49637b729a11db9e1dac2d983cd",
@@ -294,11 +239,11 @@
         },
         "pytz": {
             "hashes": [
-                "sha256:31cb35c89bd7d333cd32c5f278fca91b523b0834369e757f4c5641ea252236ca",
-                "sha256:8e0f8568c118d3077b46be7d654cc8167fa916092e28320cde048e54bfc9f1e6"
+                "sha256:32b0891edff07e28efe91284ed9c31e123d84bea3fd98e1f72be2508f43ef8d9",
+                "sha256:d5f05e487007e29e03409f9398d074e158d920d36eb82eaf66fb1136b0c5374c"
             ],
             "index": "pypi",
-            "version": "==2018.7"
+            "version": "==2018.9"
         },
         "pyyaml": {
             "hashes": [
@@ -338,26 +283,12 @@
             "index": "pypi",
             "version": "==2.21.0"
         },
-        "retry": {
-            "hashes": [
-                "sha256:ccddf89761fa2c726ab29391837d4327f819ea14d244c232a1d24c67a2f98606",
-                "sha256:f8bfa8b99b69c4506d6f5bd3b0aabf77f98cdb17f3c9fc3f5ca820033336fba4"
-            ],
-            "version": "==0.9.2"
-        },
         "s3transfer": {
             "hashes": [
                 "sha256:7b9ad3213bff7d357f888e0fab5101b56fa1a0548ee77d121c3a3dbfbef4cb2e",
                 "sha256:f23d5cb7d862b104401d9021fc82e5fa0e0cf57b7660a1331425aab0c691d021"
             ],
             "version": "==0.2.0"
-        },
-        "semver": {
-            "hashes": [
-                "sha256:41c9aa26c67dc16c54be13074c352ab666bce1fa219c7110e8f03374cd4206b0",
-                "sha256:5b09010a66d9a3837211bb7ae5a20d10ba88f8cb49e92cb139a69ef90d5060d8"
-            ],
-            "version": "==2.8.1"
         },
         "six": {
             "hashes": [
@@ -373,13 +304,6 @@
             "index": "pypi",
             "version": "==1.2.17"
         },
-        "unidecode": {
-            "hashes": [
-                "sha256:092cdf7ad9d1052c50313426a625b717dab52f7ac58f859e09ea020953b1ad8f",
-                "sha256:8b85354be8fd0c0e10adbf0675f6dc2310e56fda43fa8fe049123b6c475e52fb"
-            ],
-            "version": "==1.0.23"
-        },
         "urllib3": {
             "hashes": [
                 "sha256:61bf29cada3fc2fbefad4fdf059ea4bd1b4a86d2b6d15e1c7c0b582b9752fe39",
@@ -394,13 +318,6 @@
             ],
             "index": "pypi",
             "version": "==2.0.18"
-        },
-        "vine": {
-            "hashes": [
-                "sha256:133ee6d7a9016f177ddeaf191c1f58421a1dcc6ee9a42c58b34bed40e1d2cd87",
-                "sha256:ea4947cc56d1fd6f2095c8d543ee25dad966f78692528e68b4fada11ba3f98af"
-            ],
-            "version": "==1.3.0"
         },
         "webencodings": {
             "hashes": [
@@ -490,11 +407,11 @@
         },
         "coveralls": {
             "hashes": [
-                "sha256:6f213e461390973f4a97fb9e9d4ebd4956af296ff0a4d868e622108145835cb7",
-                "sha256:a7d0078c9e9b5692c03dcd3884647e837836c265c01e98094632feadef767d36"
+                "sha256:baa26648430d5c2225ab12d7e2067f75597a4b967034bba7e3d5ab7501d207a1",
+                "sha256:ff9b7823b15070f26f654837bb02a201d006baaf2083e0514ffd3b34a3ffed81"
             ],
             "index": "pypi",
-            "version": "==1.6.0"
+            "version": "==1.7.0"
         },
         "docopt": {
             "hashes": [
@@ -628,11 +545,11 @@
         },
         "pytz": {
             "hashes": [
-                "sha256:31cb35c89bd7d333cd32c5f278fca91b523b0834369e757f4c5641ea252236ca",
-                "sha256:8e0f8568c118d3077b46be7d654cc8167fa916092e28320cde048e54bfc9f1e6"
+                "sha256:32b0891edff07e28efe91284ed9c31e123d84bea3fd98e1f72be2508f43ef8d9",
+                "sha256:d5f05e487007e29e03409f9398d074e158d920d36eb82eaf66fb1136b0c5374c"
             ],
             "index": "pypi",
-            "version": "==2018.7"
+            "version": "==2018.9"
         },
         "requests": {
             "hashes": [

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "dde466a65ea4b0d0142c206521ff0e4ffab2f488e3df687c85c0acf8d9f69cb9"
+            "sha256": "33db1390e71206b0a737d2997d7e0d79525b00518a8e555fdedd9ff0f4d177e6"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -37,10 +37,10 @@
         },
         "arxiv-submission-core": {
             "hashes": [
-                "sha256:758b28181a07ed4a8d1994dbfcf59755bf2ccc394b640ce5d7d5ff653c9ea27c"
+                "sha256:c5203d4363f06dcd8fe6c30127b87b52761f22c79e9d7094a5927daeacd24bea"
             ],
             "index": "pypi",
-            "version": "==0.7.1rc3"
+            "version": "==0.7.1rc4"
         },
         "attrs": {
             "hashes": [

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "996f32af7d739acce93451f719734436a1d3c129980cc67ef3e7df2b1e1e01be"
+            "sha256": "dde466a65ea4b0d0142c206521ff0e4ffab2f488e3df687c85c0acf8d9f69cb9"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -14,6 +14,13 @@
         ]
     },
     "default": {
+        "amqp": {
+            "hashes": [
+                "sha256:043beb485774ca69718a35602089e524f87168268f0d1ae115f28b88d27f92d7",
+                "sha256:35a3b5006ca00b21aaeec8ceea07130f07b902dd61bfe42815039835f962f5f1"
+            ],
+            "version": "==2.4.2"
+        },
         "arxiv-auth": {
             "hashes": [
                 "sha256:440b3f18a9cc0ce36fbffd5d6f565c33215f118619bc2c3f35f1c1adad74dad8"
@@ -27,6 +34,13 @@
             ],
             "index": "pypi",
             "version": "==0.15.3rc7"
+        },
+        "arxiv-submission-core": {
+            "hashes": [
+                "sha256:758b28181a07ed4a8d1994dbfcf59755bf2ccc394b640ce5d7d5ff653c9ea27c"
+            ],
+            "index": "pypi",
+            "version": "==0.7.1rc3"
         },
         "attrs": {
             "hashes": [
@@ -42,6 +56,12 @@
             "index": "pypi",
             "version": "==1.0.0"
         },
+        "billiard": {
+            "hashes": [
+                "sha256:42d9a227401ac4fba892918bba0a0c409def5435c4b483267ebfe821afaaba0e"
+            ],
+            "version": "==3.5.0.5"
+        },
         "bleach": {
             "hashes": [
                 "sha256:213336e49e102af26d9cde77dd2d0397afabc5a6bf2fed985dc35b5d1e285a16",
@@ -52,17 +72,24 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:80f24c01a630e6be409d70aa1b1e30076eda1daf8456157ec210aea2d8d51f2c",
-                "sha256:f259046902b1daa542a08f08796d000160e9801a87f470faf940addacedcc7d7"
+                "sha256:25bf66529b94fc9b89928fd5fd004d4a15c7e9603b44692e9652b8fc526699c3",
+                "sha256:60b6f8ce0f2213b070ad67851466b7e8467061efe9536df467f61402c2110a9f"
             ],
-            "version": "==1.9.117"
+            "version": "==1.9.119"
         },
         "botocore": {
             "hashes": [
-                "sha256:6c3b1b3344d7bb53a85d3877047e5f29a46f13deb27bda2e85a6d24d7a27c5bf",
-                "sha256:c2a8ae81bb2dfd70951279a1b63ba7ef89333675f9ff479b008ce14fcd9872c1"
+                "sha256:22e8c1a52aea4511a276926400bc2a2209c6cd96e75d144696c5e5b405775914",
+                "sha256:92e8cf18e220aadef3db0ef724537a8b3414f2836d99a972e09b9c9bd4001295"
             ],
-            "version": "==1.12.117"
+            "version": "==1.12.119"
+        },
+        "celery": {
+            "hashes": [
+                "sha256:77ff3730198d6a17b3c1f05579ebe570b579efb35f6d7e13dba3b1368d068b35",
+                "sha256:81a67f0d53a688ec2bc8557bd5d6d7218f925a6f2e6df80e01560de9e28997ec"
+            ],
+            "version": "==4.1.0"
         },
         "certifi": {
             "hashes": [
@@ -93,6 +120,13 @@
             "index": "pypi",
             "version": "==0.6"
         },
+        "decorator": {
+            "hashes": [
+                "sha256:86156361c50488b84a3f148056ea716ca587df2f0de1d34750d35c21312725de",
+                "sha256:f069f3a01830ca754ba5258fde2278454a0b5b79e0d7f5c13b3b97e57d4acff6"
+            ],
+            "version": "==4.4.0"
+        },
         "docutils": {
             "hashes": [
                 "sha256:02aec4bd92ab067f6ff27a38a38a41173bf01bed8f89157768c1573f53e474a6",
@@ -116,6 +150,13 @@
             ],
             "index": "pypi",
             "version": "==0.3.1"
+        },
+        "flask-sqlalchemy": {
+            "hashes": [
+                "sha256:3bc0fac969dd8c0ace01b32060f0c729565293302f0c4269beed154b46bec50b",
+                "sha256:5971b9852b5888655f11db634e87725a9031e170f37c0ce7851cf83497f56e53"
+            ],
+            "version": "==2.3.2"
         },
         "idna": {
             "hashes": [
@@ -152,6 +193,13 @@
             ],
             "index": "pypi",
             "version": "==3.0.1"
+        },
+        "kombu": {
+            "hashes": [
+                "sha256:01f0da9fe222a2183345004243d1518c0fbe5875955f1b24842f2d9c65709ade",
+                "sha256:4249d9dd9dbf1fcec471d1c2def20653c9310dd1a217272d77e4844f9d5273cb"
+            ],
+            "version": "==4.1.0"
         },
         "markupsafe": {
             "hashes": [
@@ -209,6 +257,13 @@
             "index": "pypi",
             "version": "==1.4.2"
         },
+        "py": {
+            "hashes": [
+                "sha256:64f65755aee5b381cea27766a3a147c3f15b9b6b9ac88676de66ba2ae36793fa",
+                "sha256:dc639b046a6e2cff5bbe40194ad65936d6ba360b52b3c3fe1d08a82dd50b5e53"
+            ],
+            "version": "==1.8.0"
+        },
         "pycountry": {
             "hashes": [
                 "sha256:104a8ca94c700898c42a0172da2eab5a5675c49637b729a11db9e1dac2d983cd",
@@ -239,11 +294,11 @@
         },
         "pytz": {
             "hashes": [
-                "sha256:32b0891edff07e28efe91284ed9c31e123d84bea3fd98e1f72be2508f43ef8d9",
-                "sha256:d5f05e487007e29e03409f9398d074e158d920d36eb82eaf66fb1136b0c5374c"
+                "sha256:31cb35c89bd7d333cd32c5f278fca91b523b0834369e757f4c5641ea252236ca",
+                "sha256:8e0f8568c118d3077b46be7d654cc8167fa916092e28320cde048e54bfc9f1e6"
             ],
             "index": "pypi",
-            "version": "==2018.9"
+            "version": "==2018.7"
         },
         "pyyaml": {
             "hashes": [
@@ -283,12 +338,26 @@
             "index": "pypi",
             "version": "==2.21.0"
         },
+        "retry": {
+            "hashes": [
+                "sha256:ccddf89761fa2c726ab29391837d4327f819ea14d244c232a1d24c67a2f98606",
+                "sha256:f8bfa8b99b69c4506d6f5bd3b0aabf77f98cdb17f3c9fc3f5ca820033336fba4"
+            ],
+            "version": "==0.9.2"
+        },
         "s3transfer": {
             "hashes": [
                 "sha256:7b9ad3213bff7d357f888e0fab5101b56fa1a0548ee77d121c3a3dbfbef4cb2e",
                 "sha256:f23d5cb7d862b104401d9021fc82e5fa0e0cf57b7660a1331425aab0c691d021"
             ],
             "version": "==0.2.0"
+        },
+        "semver": {
+            "hashes": [
+                "sha256:41c9aa26c67dc16c54be13074c352ab666bce1fa219c7110e8f03374cd4206b0",
+                "sha256:5b09010a66d9a3837211bb7ae5a20d10ba88f8cb49e92cb139a69ef90d5060d8"
+            ],
+            "version": "==2.8.1"
         },
         "six": {
             "hashes": [
@@ -303,6 +372,13 @@
             ],
             "index": "pypi",
             "version": "==1.2.17"
+        },
+        "unidecode": {
+            "hashes": [
+                "sha256:092cdf7ad9d1052c50313426a625b717dab52f7ac58f859e09ea020953b1ad8f",
+                "sha256:8b85354be8fd0c0e10adbf0675f6dc2310e56fda43fa8fe049123b6c475e52fb"
+            ],
+            "version": "==1.0.23"
         },
         "urllib3": {
             "hashes": [
@@ -319,6 +395,13 @@
             "index": "pypi",
             "version": "==2.0.18"
         },
+        "vine": {
+            "hashes": [
+                "sha256:133ee6d7a9016f177ddeaf191c1f58421a1dcc6ee9a42c58b34bed40e1d2cd87",
+                "sha256:ea4947cc56d1fd6f2095c8d543ee25dad966f78692528e68b4fada11ba3f98af"
+            ],
+            "version": "==1.3.0"
+        },
         "webencodings": {
             "hashes": [
                 "sha256:a0af1213f3c2226497a97e2b3aa01a7e4bee4f403f95be16fc9acd2947514a78",
@@ -328,10 +411,10 @@
         },
         "werkzeug": {
             "hashes": [
-                "sha256:590abe38f8be026d78457fe3b5200895b3543e58ac3fc1dd792c6333ea11af64",
-                "sha256:ee11b0f0640c56fb491b43b38356c4b588b3202b415a1e03eacf1c5561c961cf"
+                "sha256:96da23fa8ccecbc3ae832a83df5c722c11547d021637faacb0bec4dd2f4666c8",
+                "sha256:ca5c2dcd367d6c0df87185b9082929d255358f5391923269335782b213d52655"
             ],
-            "version": "==0.15.0"
+            "version": "==0.15.1"
         },
         "wtforms": {
             "hashes": [
@@ -545,11 +628,11 @@
         },
         "pytz": {
             "hashes": [
-                "sha256:32b0891edff07e28efe91284ed9c31e123d84bea3fd98e1f72be2508f43ef8d9",
-                "sha256:d5f05e487007e29e03409f9398d074e158d920d36eb82eaf66fb1136b0c5374c"
+                "sha256:31cb35c89bd7d333cd32c5f278fca91b523b0834369e757f4c5641ea252236ca",
+                "sha256:8e0f8568c118d3077b46be7d654cc8167fa916092e28320cde048e54bfc9f1e6"
             ],
             "index": "pypi",
-            "version": "==2018.9"
+            "version": "==2018.7"
         },
         "requests": {
             "hashes": [
@@ -575,11 +658,11 @@
         },
         "sphinx": {
             "hashes": [
-                "sha256:230af939a2f678ab4f2a0a948c3b24a822a0d280821859caaefb750ef7413003",
-                "sha256:835c701420102a0a71ba2ed54a5bada2da6fd01263bf6dc8c5c80c798e27709c"
+                "sha256:821df39e44b8127043e09b80a312ff0fdb45fe88e10b1515b8c8b9652322df34",
+                "sha256:bc3714ad839a265ef08fa6ad3b990bb884e64401a75e4980549bd9ef5e649aa7"
             ],
             "index": "pypi",
-            "version": "==2.0.0b1"
+            "version": "==2.0.0b2"
         },
         "sphinx-autodoc-typehints": {
             "hashes": [

--- a/app.py
+++ b/app.py
@@ -5,7 +5,9 @@ from arxiv.submission.services import classic
 import logging
 
 logging.getLogger('arxiv.submission.services.classic.interpolate') \
-    .setLevel(logging.ERROR)
+    .setLevel(logging.DEBUG)
+logging.getLogger('arxiv.submission.services.classic.models') \
+    .setLevel(logging.DEBUG)
 logging.getLogger('arxiv.base.alerts').setLevel(logging.ERROR)
 
 app = create_ui_web_app()

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -64,6 +64,7 @@ with app.app_context():
             scopes.CREATE_SUBMISSION,
             scopes.EDIT_SUBMISSION,
             scopes.VIEW_SUBMISSION,
+            scopes.DELETE_SUBMISSION,
             scopes.READ_UPLOAD,
             scopes.WRITE_UPLOAD,
             scopes.DELETE_UPLOAD_FILE,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -82,7 +82,7 @@ services:
 
   filemanager:
     << : *base-service
-    image: arxiv/filemanager:0.0
+    image: arxiv/filemanager:0.0.2
     # You can uncomment these lines to build this from a local
     # repo. You may need to update `context`.
     # build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -150,7 +150,7 @@ services:
 
   submission-worker:
     << : *base-service
-    image: arxiv/submission-worker:0.0.3
+    image: arxiv/submission-worker:0.0.5
     container_name: arxiv-submission-worker
     networks:
       - arxiv-submission-ui

--- a/submit/controllers/cross.py
+++ b/submit/controllers/cross.py
@@ -129,10 +129,10 @@ def request_cross(method: str, params: MultiDict, session: Session,
     # Will raise NotFound if there is no such submission.
     submission, submission_events = load_submission(submission_id)
 
-    # The submission must be published for this to be a cross-list request.
-    if not submission.published:
+    # The submission must be announced for this to be a cross-list request.
+    if not submission.announced:
         alerts.flash_failure(
-            Markup("Submission must first be published. See <a"
+            Markup("Submission must first be announced. See <a"
                    " href='https://arxiv.org/help/cross'>the arXiv help"
                    " pages</a> for details."))
         status_url = url_for('ui.create_submission')
@@ -161,7 +161,7 @@ def request_cross(method: str, params: MultiDict, session: Session,
     if method == 'POST':
         if not form.validate():
             raise BadRequest(response_data)
-            
+
         if form.confirmed.data:     # Stop adding new categories, and submit.
             response_data['form'].operation.data = CrossListForm.ADD
             response_data['require_confirmation'] = True

--- a/submit/controllers/delete.py
+++ b/submit/controllers/delete.py
@@ -1,13 +1,17 @@
 """Provides controllers used to delete/roll back a submission."""
 
+from typing import Optional
+
 from flask import url_for
 from wtforms import BooleanField, validators
 from werkzeug import MultiDict
-from werkzeug.exceptions import BadRequest, InternalServerError
+from werkzeug.exceptions import BadRequest, InternalServerError, NotFound
 
 from http import HTTPStatus as status
 from arxiv.base import logging, alerts
-from arxiv.submission import Rollback, save
+from arxiv.submission import Rollback, save, CancelRequest
+from arxiv.submission.domain import WithdrawalRequest, \
+    CrossListClassificationRequest, UserRequest
 from arxiv.forms import csrf
 from arxiv.users.domain import Session
 from .util import Response, user_and_client_from_session, validate_command
@@ -16,6 +20,13 @@ from ..util import load_submission
 
 class DeleteForm(csrf.CSRFForm):
     """Form for deleting a submission or a revision."""
+
+    confirmed = BooleanField('Confirmed',
+                             validators=[validators.DataRequired()])
+
+
+class CancelRequestForm(csrf.CSRFForm):
+    """Form for cancelling a request."""
 
     confirmed = BooleanField('Confirmed',
                              validators=[validators.DataRequired()])
@@ -56,6 +67,62 @@ def delete(method: str, params: MultiDict, session: Session,
                 save(command, submission_id=submission_id)
             except Exception as e:
                 alerts.flash_failure("Whoops!")
+                raise InternalServerError(response_data) from e
+            redirect = url_for('ui.create_submission')
+            return {}, status.SEE_OTHER, {'Location': redirect}
+        response_data.update({'form': form})
+        raise BadRequest(response_data)
+
+
+def cancel_request(method: str, params: MultiDict, session: Session,
+                   submission_id: int, request_type: str,
+                   **kwargs) -> Response:
+    submission, submission_events = load_submission(submission_id)
+
+    if request_type == WithdrawalRequest.NAME.lower():
+        request_klass = WithdrawalRequest
+    elif request_type == CrossListClassificationRequest.NAME.lower():
+        request_klass = CrossListClassificationRequest
+    else:
+        raise NotFound('No such request')
+
+    # Get the most recent user request of this type.
+    this_request: Optional[UserRequest] = None
+    for user_request in submission.active_user_requests[::-1]:
+        if isinstance(user_request, request_klass):
+            this_request = user_request
+            break
+    if this_request is None:
+        raise NotFound('No such request')
+
+    if not this_request.is_pending():
+        raise BadRequest(f'Request is already {this_request.status}')
+
+    response_data = {
+        'submission': submission,
+        'submission_id': submission.submission_id,
+        'request_id': this_request.request_id,
+        'user_request': this_request,
+    }
+
+    if method == 'GET':
+        form = CancelRequestForm()
+        response_data.update({'form': form})
+        return response_data, status.OK, {}
+    elif method == 'POST':
+        form = CancelRequestForm(params)
+        response_data.update({'form': form})
+        if form.validate() and form.confirmed.data:
+            user, client = user_and_client_from_session(session)
+            command = CancelRequest(request_id=this_request.request_id,
+                                    creator=user, client=client)
+            if not validate_command(form, command, submission, 'confirmed'):
+                raise BadRequest(response_data)
+
+            try:
+                save(command, submission_id=submission_id)
+            except Exception as e:
+                alerts.flash_failure("Whoops!" + str(e))
                 raise InternalServerError(response_data) from e
             redirect = url_for('ui.create_submission')
             return {}, status.SEE_OTHER, {'Location': redirect}

--- a/submit/controllers/jref.py
+++ b/submit/controllers/jref.py
@@ -27,7 +27,7 @@ Response = Tuple[Dict[str, Any], int, Dict[str, Any]]  # pylint: disable=C0103
 
 
 class JREFForm(csrf.CSRFForm, FieldMixin):
-    """Set DOI and/or journal reference on a published submission."""
+    """Set DOI and/or journal reference on a announced submission."""
 
     doi = TextField('DOI', validators=[optional()],
                     description=("Full DOI of the version of record. For"
@@ -54,16 +54,16 @@ class JREFForm(csrf.CSRFForm, FieldMixin):
 
 def jref(method: str, params: MultiDict, session: Session,
          submission_id: int, **kwargs) -> Response:
-    """Set journal reference metadata on a published submission."""
+    """Set journal reference metadata on a announced submission."""
     creator, client = user_and_client_from_session(session)
     logger.debug(f'method: {method}, submission: {submission_id}. {params}')
 
     # Will raise NotFound if there is no such submission.
     submission, submission_events = load_submission(submission_id)
 
-    # The submission must be published for this to be a real JREF submission.
-    if not submission.published:
-        alerts.flash_failure(Markup("Submission must first be published. See "
+    # The submission must be announced for this to be a real JREF submission.
+    if not submission.announced:
+        alerts.flash_failure(Markup("Submission must first be announced. See "
                                     "<a href='https://arxiv.org/help/jref'>"
                                     "the arXiv help pages</a> for details."))
         status_url = url_for('ui.create_submission')

--- a/submit/controllers/metadata.py
+++ b/submit/controllers/metadata.py
@@ -117,7 +117,6 @@ def metadata(method: str, params: MultiDict, session: Session,
         if commands:   # Metadata has changed.
             if not all(valid):
                 logger.debug('Not all commands are valid')
-                print(response_data['form'].errors)
                 raise BadRequest(response_data)
 
             try:

--- a/submit/controllers/tests/test_classification.py
+++ b/submit/controllers/tests/test_classification.py
@@ -53,7 +53,7 @@ class TestClassification(TestCase):
         """GET request with a submission ID."""
         submission_id = 2
         before = mock.MagicMock(submission_id=submission_id, finalized=False,
-                                published=False, version=1, arxiv_id=None)
+                                announced=False, version=1, arxiv_id=None)
         mock_load.return_value = (before, [])
         data, code, _ = classification.classification('GET', MultiDict(),
                                                       self.session,
@@ -83,7 +83,7 @@ class TestClassification(TestCase):
         """POST request with no data."""
         submission_id = 2
         before = mock.MagicMock(submission_id=submission_id, finalized=False,
-                                published=False, version=1, arxiv_id=None)
+                                announced=False, version=1, arxiv_id=None)
         mock_load.return_value = (before, [])
 
         try:
@@ -102,7 +102,7 @@ class TestClassification(TestCase):
         """POST request with invalid category."""
         submission_id = 2
         before = mock.MagicMock(submission_id=submission_id, finalized=False,
-                                published=False, version=1, arxiv_id=None)
+                                announced=False, version=1, arxiv_id=None)
         mock_load.return_value = (before, [])
         mock_save.return_value = (before, [])
 
@@ -124,11 +124,11 @@ class TestClassification(TestCase):
         """POST request with valid category."""
         submission_id = 2
         before = mock.MagicMock(submission_id=submission_id, finalized=False,
-                                published=False, version=1, arxiv_id=None)
+                                announced=False, version=1, arxiv_id=None)
         mock_clsn = mock.MagicMock(category='astro-ph.CO')
         after = mock.MagicMock(submission_id=submission_id, finalized=False,
                                primary_classification=mock_clsn,
-                               published=False, version=1, arxiv_id=None)
+                               announced=False, version=1, arxiv_id=None)
         mock_load.return_value = (before, [])
         mock_save.return_value = (after, [])
         params = MultiDict({'category': 'astro-ph.CO'})
@@ -182,7 +182,7 @@ class TestCrossList(TestCase):
         mock_clsn = mock.MagicMock(category='astro-ph.EP')
         before = mock.MagicMock(submission_id=submission_id, finalized=False,
                                 primary_classification=mock_clsn,
-                                published=False, version=1, arxiv_id=None)
+                                announced=False, version=1, arxiv_id=None)
         mock_load.return_value = (before, [])
         params = MultiDict()
         data, code, _ = classification.cross_list('GET', params, self.session,
@@ -214,7 +214,7 @@ class TestCrossList(TestCase):
         mock_clsn = mock.MagicMock(category='astro-ph.EP')
         before = mock.MagicMock(submission_id=submission_id, finalized=False,
                                 primary_classification=mock_clsn,
-                                published=False, version=1, arxiv_id=None)
+                                announced=False, version=1, arxiv_id=None)
         mock_load.return_value = (before, [])
 
         try:
@@ -235,7 +235,7 @@ class TestCrossList(TestCase):
         mock_clsn = mock.MagicMock(category='astro-ph.EP')
         before = mock.MagicMock(submission_id=submission_id, finalized=False,
                                 primary_classification=mock_clsn,
-                                published=False, version=1, arxiv_id=None)
+                                announced=False, version=1, arxiv_id=None)
         mock_load.return_value = (before, [])
         mock_save.return_value = (before, [])
         params = MultiDict({'category': 'astro-ph'})  # <- expired
@@ -257,12 +257,12 @@ class TestCrossList(TestCase):
         mock_clsn = mock.MagicMock(category='astro-ph.EP')
         before = mock.MagicMock(submission_id=submission_id, finalized=False,
                                 primary_classification=mock_clsn,
-                                published=False, version=1, arxiv_id=None)
+                                announced=False, version=1, arxiv_id=None)
         after = mock.MagicMock(submission_id=submission_id, finalized=False,
                                primary_classification=mock_clsn,
                                secondary_categories=[
                                    mock.MagicMock(category='astro-ph.CO')
-                               ], published=False, version=1, arxiv_id=None)
+                               ], announced=False, version=1, arxiv_id=None)
         mock_load.return_value = (before, [])
         mock_save.return_value = (after, [])
         params = MultiDict({'category': 'astro-ph.CO'})

--- a/submit/controllers/tests/test_jref.py
+++ b/submit/controllers/tests/test_jref.py
@@ -56,10 +56,10 @@ class TestJREFSubmission(TestCase):
     @mock.patch(f'{jref.__name__}.url_for')
     @mock.patch(f'{jref.__name__}.JREFForm.Meta.csrf', False)
     @mock.patch('arxiv.submission.load')
-    def test_GET_with_unpublished(self, mock_load, mock_url_for, mock_alerts):
-        """GET request for an unpublished submission."""
+    def test_GET_with_unannounced(self, mock_load, mock_url_for, mock_alerts):
+        """GET request for an unannounced submission."""
         submission_id = 2
-        before = mock.MagicMock(submission_id=submission_id, published=False,
+        before = mock.MagicMock(submission_id=submission_id, announced=False,
                                 arxiv_id=None, version=1)
         mock_load.return_value = (before, [])
         mock_url_for.return_value = "/url/for/submission/status"
@@ -80,10 +80,10 @@ class TestJREFSubmission(TestCase):
     @mock.patch(f'{jref.__name__}.url_for')
     @mock.patch(f'{jref.__name__}.JREFForm.Meta.csrf', False)
     @mock.patch('arxiv.submission.load')
-    def test_POST_with_unpublished(self, mock_load, mock_url_for, mock_alerts):
-        """POST request for an unpublished submission."""
+    def test_POST_with_unannounced(self, mock_load, mock_url_for, mock_alerts):
+        """POST request for an unannounced submission."""
         submission_id = 2
-        before = mock.MagicMock(submission_id=submission_id, published=False,
+        before = mock.MagicMock(submission_id=submission_id, announced=False,
                                 arxiv_id=None, version=1)
         mock_load.return_value = (before, [])
         mock_url_for.return_value = "/url/for/submission/status"
@@ -103,10 +103,10 @@ class TestJREFSubmission(TestCase):
 
     @mock.patch(f'{jref.__name__}.JREFForm.Meta.csrf', False)
     @mock.patch('arxiv.submission.load')
-    def test_GET_with_published(self, mock_load):
-        """GET request for a published submission."""
+    def test_GET_with_announced(self, mock_load):
+        """GET request for a announced submission."""
         submission_id = 2
-        before = mock.MagicMock(submission_id=submission_id, published=True,
+        before = mock.MagicMock(submission_id=submission_id, announced=True,
                                 arxiv_id='2002.01234', version=1)
         mock_load.return_value = (before, [])
         params = MultiDict()
@@ -119,10 +119,10 @@ class TestJREFSubmission(TestCase):
     @mock.patch(f'{jref.__name__}.JREFForm.Meta.csrf', False)
     @mock.patch('arxiv.submission.load')
     @mock.patch(f'{jref.__name__}.save', mock_save)
-    def test_POST_with_published(self, mock_load, mock_url_for, mock_alerts):
-        """POST request for a published submission."""
+    def test_POST_with_announced(self, mock_load, mock_url_for, mock_alerts):
+        """POST request for a announced submission."""
         submission_id = 2
-        before = mock.MagicMock(submission_id=submission_id, published=True,
+        before = mock.MagicMock(submission_id=submission_id, announced=True,
                                 arxiv_id='2002.01234', version=1)
         mock_load.return_value = (before, [])
         mock_url_for.return_value = "/url/for/submission/status"

--- a/submit/controllers/tests/test_primary.py
+++ b/submit/controllers/tests/test_primary.py
@@ -52,7 +52,7 @@ class TestSetPrimaryClassification(TestCase):
     def test_get_request_with_submission(self, mock_load):
         """GET request with a submission ID."""
         submission_id = 2
-        before = mock.MagicMock(submission_id=submission_id, published=False,
+        before = mock.MagicMock(submission_id=submission_id, announced=False,
                                 arxiv_id=None, submitter_is_author=False,
                                 finalized=False, version=1)
         mock_load.return_value = (before, [])
@@ -84,7 +84,7 @@ class TestSetPrimaryClassification(TestCase):
     def test_post_request(self, mock_load):
         """POST request with no data."""
         submission_id = 2
-        before = mock.MagicMock(submission_id=submission_id, published=False,
+        before = mock.MagicMock(submission_id=submission_id, announced=False,
                                 arxiv_id=None, submitter_is_author=False,
                                 finalized=False, version=1)
         mock_load.return_value = (before, [])
@@ -105,11 +105,11 @@ class TestSetPrimaryClassification(TestCase):
         """POST request with `classification` set."""
         # Event store does not complain; returns object with `submission_id`.
         submission_id = 2
-        before = mock.MagicMock(submission_id=submission_id, published=False,
+        before = mock.MagicMock(submission_id=submission_id, announced=False,
                                 arxiv_id=None, submitter_is_author=False,
                                 finalized=False, version=1)
         mock_clsn = mock.MagicMock(category='astro-ph.CO')
-        after = mock.MagicMock(submission_id=submission_id, published=False,
+        after = mock.MagicMock(submission_id=submission_id, announced=False,
                                arxiv_id=None, submitter_is_author=False,
                                primary_classification=mock_clsn,
                                finalized=False, version=1)
@@ -130,7 +130,7 @@ class TestSetPrimaryClassification(TestCase):
     def test_save_error(self, mock_load, mock_save, mock_url_for):
         """Event store flakes out on saving classification event."""
         submission_id = 2
-        before = mock.MagicMock(submission_id=submission_id, published=False,
+        before = mock.MagicMock(submission_id=submission_id, announced=False,
                                 arxiv_id=None, submitter_is_author=False,
                                 finalized=False, version=1)
         mock_load.return_value = (before, [])

--- a/submit/controllers/tests/test_upload.py
+++ b/submit/controllers/tests/test_upload.py
@@ -56,7 +56,7 @@ class TestUpload(TestCase):
         """GET request for submission with no upload package."""
         submission_id = 2
         subm = mock.MagicMock(submission_id=submission_id, source_content=None,
-                              finalized=False, published=False, arxiv_id=None,
+                              finalized=False, announced=False, arxiv_id=None,
                               version=1)
         mock_load.return_value = (subm, [])
         params = MultiDict({})
@@ -84,7 +84,7 @@ class TestUpload(TestCase):
                     compressed_size=1000,
                     source_format=SubmissionContent.Format.TEX
                 ),
-                finalized=False, published=False, arxiv_id=None, version=1
+                finalized=False, announced=False, arxiv_id=None, version=1
             ), []
         )
         mock_filemanager.get_upload_status.return_value = (
@@ -141,7 +141,7 @@ class TestUpload(TestCase):
                 compressed_size=1000,
                 source_format=SubmissionContent.Format.TEX
             ),
-            finalized=False, published=False, arxiv_id=None, version=1
+            finalized=False, announced=False, arxiv_id=None, version=1
         )
         mock_load.return_value = (mock_submission, [])
         mock_save.return_value = (mock_submission, [])
@@ -228,7 +228,7 @@ class TestDelete(TestCase):
                     compressed_size=1000,
                     source_format=SubmissionContent.Format.TEX
                 ),
-                finalized=False, published=False, arxiv_id=None, version=1
+                finalized=False, announced=False, arxiv_id=None, version=1
             ), []
         )
         file_path = 'anc/foo.jpeg'
@@ -256,7 +256,7 @@ class TestDelete(TestCase):
                     compressed_size=1000,
                     source_format=SubmissionContent.Format.TEX
                 ),
-                finalized=False, published=False, arxiv_id=None, version=1
+                finalized=False, announced=False, arxiv_id=None, version=1
             ), []
         )
         file_path = 'anc/foo.jpeg'
@@ -290,7 +290,7 @@ class TestDelete(TestCase):
                     compressed_size=1000,
                     source_format=SubmissionContent.Format.TEX
                 ),
-                finalized=False, published=False, arxiv_id=None, version=1
+                finalized=False, announced=False, arxiv_id=None, version=1
             ), []
         )
         mock_save.return_value = (
@@ -303,7 +303,7 @@ class TestDelete(TestCase):
                     compressed_size=1000,
                     source_format=SubmissionContent.Format.TEX
                 ),
-                finalized=False, published=False, arxiv_id=None, version=1
+                finalized=False, announced=False, arxiv_id=None, version=1
             ), []
         )
         file_path = 'anc/foo.jpeg'

--- a/submit/controllers/upload.py
+++ b/submit/controllers/upload.py
@@ -361,11 +361,13 @@ def _update(form: UploadForm, submission: Submission, stat: Upload,
         command = UpdateUploadPackage(creator=submitter, client=client,
                                       checksum=stat.checksum,
                                       uncompressed_size=stat.size,
+                                      compressed_size=stat.compressed_size,
                                       source_format=stat.source_format)
     else:
         command = SetUploadPackage(creator=submitter, client=client,
                                    identifier=stat.identifier,
                                    checksum=stat.checksum,
+                                   compressed_size=stat.compressed_size,
                                    uncompressed_size=stat.size,
                                    source_format=stat.source_format)
 

--- a/submit/controllers/withdraw.py
+++ b/submit/controllers/withdraw.py
@@ -45,10 +45,10 @@ def request_withdrawal(method: str, params: MultiDict, session: Session,
     # Will raise NotFound if there is no such submission.
     submission, _ = load_submission(submission_id)
 
-    # The submission must be published for this to be a withdrawal request.
-    if not submission.published:
+    # The submission must be announced for this to be a withdrawal request.
+    if not submission.announced:
         alerts.flash_failure(Markup(
-            "Submission must first be published. See "
+            "Submission must first be announced. See "
             "<a href='https://arxiv.org/help/withdraw'>the arXiv help pages"
             "</a> for details."
         ))

--- a/submit/domain/__init__.py
+++ b/submit/domain/__init__.py
@@ -106,6 +106,9 @@ class Upload(NamedTuple):
     source_format: SubmissionContent.Format = SubmissionContent.Format.UNKNOWN
     checksum: Optional[str] = None
     size: Optional[int] = None
+    """Size in bytes of the uncompressed upload workspace."""
+    compressed_size: Optional[int] = None
+    """Size in bytes of the compressed upload package."""
     files: List[FileStatus] = []
     errors: List[FileError] = []
 

--- a/submit/flow_control.py
+++ b/submit/flow_control.py
@@ -19,13 +19,15 @@ logger = logging.getLogger(__name__)
 EXIT = 'ui.create_submission'
 
 
-def get_workflow(submission: Submission) -> Workflow:
-    if submission.version > 1:
+def get_workflow(submission: Optional[Submission]) -> Workflow:
+    if submission is not None and submission.version > 1:
         return ReplacementWorkflow(submission, session)
     return SubmissionWorkflow(submission, session)
 
 
 def to_stage(workflow: Workflow, stage: Stage, ident: str) -> Response:
+    if stage is None:
+        return redirect(url_for('ui.create_submission'), code=status.SEE_OTHER)
     loc = url_for(f'ui.{stage.endpoint}', submission_id=ident)
     return redirect(loc, code=status.SEE_OTHER)
 

--- a/submit/routes/ui.py
+++ b/submit/routes/ui.py
@@ -156,6 +156,15 @@ def delete_submission(submission_id: int):
                   'Delete submission or replacement', submission_id)
 
 
+@ui.route(path('cancel/<string:request_type>'), methods=["GET", "POST"])
+@auth.decorators.scoped(auth.scopes.EDIT_SUBMISSION, authorizer=is_owner)
+def cancel_request(submission_id: int, request_type: str):
+    """Cancel a pending request."""
+    return handle(controllers.delete.cancel_request,
+                  'submit/confirm_cancel_request.html', 'Cancel request',
+                  submission_id, request_type=request_type)
+
+
 @ui.route(path('replace'), methods=["POST"])
 @auth.decorators.scoped(auth.scopes.EDIT_SUBMISSION, authorizer=is_owner)
 def create_replacement(submission_id: int):

--- a/submit/routes/ui.py
+++ b/submit/routes/ui.py
@@ -50,10 +50,10 @@ def load_submission() -> None:
             util.load_submission(submission_id)
     except Unavailable as e:
         raise InternalServerError('Could not connect to database') from e
-    except Exception as e:
-        logger.error('Encountered %s while loading %s', e, submission_id)
-        request.submission = None
-        request.events = None
+    # except Exception as e:
+    #     logger.error('Encountered %s while loading %s', e, submission_id)
+    #     request.submission = None
+    #     request.events = None
 
 
 @ui.context_processor
@@ -150,19 +150,19 @@ def create_submission():
 @ui.route(path('delete'), methods=["GET", "POST"])
 @auth.decorators.scoped(auth.scopes.DELETE_SUBMISSION, authorizer=is_owner)
 def delete_submission(submission_id: int):
-    """Delete, or roll a submission back to the last published state."""
+    """Delete, or roll a submission back to the last announced state."""
     return handle(controllers.delete.delete,
                   'submit/confirm_delete_submission.html',
                   'Delete submission or replacement', submission_id)
 
 
-@ui.route(path('cancel/<string:request_type>'), methods=["GET", "POST"])
+@ui.route(path('cancel/<string:request_id>'), methods=["GET", "POST"])
 @auth.decorators.scoped(auth.scopes.EDIT_SUBMISSION, authorizer=is_owner)
-def cancel_request(submission_id: int, request_type: str):
+def cancel_request(submission_id: int, request_id: str):
     """Cancel a pending request."""
     return handle(controllers.delete.cancel_request,
                   'submit/confirm_cancel_request.html', 'Cancel request',
-                  submission_id, request_type=request_type)
+                  submission_id, request_id=request_id)
 
 
 @ui.route(path('replace'), methods=["POST"])
@@ -182,11 +182,11 @@ def submission_status(submission_id: int) -> Response:
 
 
 # TODO: remove me!!
-@ui.route(path('publish'), methods=["GET"])
+@ui.route(path('announce'), methods=["GET"])
 @auth.decorators.scoped(auth.scopes.EDIT_SUBMISSION, authorizer=is_owner)
-def publish(submission_id: int) -> Response:
+def announce(submission_id: int) -> Response:
     """WARNING WARNING WARNING this is for testing purposes only."""
-    util.publish_submission(submission_id)
+    util.announce_submission(submission_id)
     target = url_for('ui.submission_status', submission_id=submission_id)
     return Response(response={}, status=status.SEE_OTHER,
                     headers={'Location': target})

--- a/submit/services/filemanager.py
+++ b/submit/services/filemanager.py
@@ -82,6 +82,7 @@ class FileManager(service.HTTPIntegration):
                 ) for fdata in data['files']
             ],
             errors=non_file_errors,
+            compressed_size=data['upload_compressed_size'],
             size=data['upload_total_size'],
             checksum=data['checksum'],
             source_format=SubmissionContent.Format(data['source_format'])

--- a/submit/services/tests/test_filemanager_integration.py
+++ b/submit/services/tests/test_filemanager_integration.py
@@ -28,7 +28,7 @@ class TestFileManagerIntegration(TestCase):
         print('starting file management service')
         os.environ['JWT_SECRET'] = 'foosecret'
         start_fm = subprocess.run(
-            'docker run -d -e JWT_SECRET=foosecret -p 8003:8000 arxiv/filemanager:0.1rc2 /bin/bash -c \'python bootstrap.py; uwsgi --http-socket :8000 -M -t 3000 --manage-script-name --processes 8 --threads 1 --async 100 --ugreen --mount /=/opt/arxiv/wsgi.py --logformat "%(addr) %(addr) - %(user_id)|%(session_id) [%(rtime)] [%(uagent)] \\"%(method) %(uri) %(proto)\\" %(status) %(size) %(micros) %(ttfb)"\'',
+            'docker run -d -e JWT_SECRET=foosecret -p 8003:8000 arxiv/filemanager:0.0.2 /bin/bash -c \'python bootstrap.py; uwsgi --http-socket :8000 -M -t 3000 --manage-script-name --processes 8 --threads 1 --async 100 --ugreen --mount /=/opt/arxiv/wsgi.py --logformat "%(addr) %(addr) - %(user_id)|%(session_id) [%(rtime)] [%(uagent)] \\"%(method) %(uri) %(proto)\\" %(status) %(size) %(micros) %(ttfb)"\'',
             stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
 
         if start_fm.returncode != 0:

--- a/submit/templates/submit/confirm_cancel_request.html
+++ b/submit/templates/submit/confirm_cancel_request.html
@@ -1,0 +1,36 @@
+{% extends "submit/base.html" %}
+
+{% import "submit/submit_macros.html" as submit_macros %}
+
+{% block title_preamble %}{% endblock %}
+{% block title -%}Cancel {{ user_request.NAME }} Request for E-print {{ submission.arxiv_id }}{%- endblock title %}
+
+
+{% block within_content %}
+<h2>{{ submission.metadata.title }}</h2>
+
+
+<form method="POST" action="{{ url_for('ui.cancel_request', submission_id=submission_id, request_type=user_request.NAME.lower()) }}">
+  {{ form.csrf_token }}
+  <div class="columns">
+    <div class="column is-half is-offset-one-quarter">
+    <article class="message is-primary breathe-vertical">
+      <div class="message-header">
+        <p>Delete {{ user_request.NAME }} Request</p>
+      </div>
+      <div class="message-body">
+        <p>
+          Are you sure that you want to cancel this {{ user_request.NAME }} request?
+        </p>
+        {{ form.csrf_token }}
+        <input type="hidden" name="confirmed", value="true" />
+        <div class="buttons is-centered">
+            <button class="button is-primary" type="submit">Yes, cancel this request</button>
+            <a class="button" href="{% if url_to_safety %}{{ url_to_safety }}{% else %}{{ url_for('ui.create_submission') }}{% endif %}">No, keep working</a>
+        </div>
+      </div>
+    </article>
+    </div>
+  </div>
+</form>
+{% endblock within_content %}

--- a/submit/templates/submit/confirm_cancel_request.html
+++ b/submit/templates/submit/confirm_cancel_request.html
@@ -10,7 +10,7 @@
 <h2>{{ submission.metadata.title }}</h2>
 
 
-<form method="POST" action="{{ url_for('ui.cancel_request', submission_id=submission_id, request_type=user_request.NAME.lower()) }}">
+<form method="POST" action="{{ url_for('ui.cancel_request', submission_id=submission_id, request_id=user_request.request_id) }}">
   {{ form.csrf_token }}
   <div class="columns">
     <div class="column is-half is-offset-one-quarter">

--- a/submit/templates/submit/confirm_delete_submission.html
+++ b/submit/templates/submit/confirm_delete_submission.html
@@ -21,7 +21,7 @@
             uploaded for this submission from your account. Are you sure you
             want to delete?
           {% else %}
-            Deleting will revert your article to the most recently published
+            Deleting will revert your article to the most recently announced
             and announced version and discard any new information entered or
             uploaded during this replacement. Are you sure you want to delete?
           {% endif %}

--- a/submit/templates/submit/confirm_delete_submission.html
+++ b/submit/templates/submit/confirm_delete_submission.html
@@ -22,7 +22,7 @@
             want to delete?
           {% else %}
             Deleting will revert your article to the most recently announced
-            and announced version and discard any new information entered or
+            version, and discard any new information entered or
             uploaded during this replacement. Are you sure you want to delete?
           {% endif %}
         </p>

--- a/submit/templates/submit/create.html
+++ b/submit/templates/submit/create.html
@@ -111,8 +111,12 @@
           {% if submission.has_active_requests %}
             {% for request in submission.active_user_requests %}
             <div class="tags has-addons">
-              <span class="tag">{{ request.NAME }}</span>
-              <span class="tag is-info">{{ request.status }}</span>
+              <span class="tag is-warning">{{ request.NAME }} {{ request.status }}</span>
+              <a href="{{ url_for('ui.cancel_request', submission_id=submission.submission_id, request_type=request.NAME.lower()) }}" class="tag is-danger">
+                  <span class="icon">
+                    <i class="fa fa-trash" aria-label="Delete"><span class="sr-only">Delete this submission</span></i>
+                  </span>
+              </a>
             </div>
             {% endfor %}
           {% else %}

--- a/submit/templates/submit/create.html
+++ b/submit/templates/submit/create.html
@@ -54,7 +54,7 @@
             <th scope="col">Actions</th>
           </tr>
         {% for submission in user_submissions %}
-          {% if not submission.published %}
+          {% if not submission.announced %}
             <tr>
               <td>{{ submission.status }}</td>
               <td>submit/{{ submission.submission_id }}</td>
@@ -93,7 +93,7 @@
 <section class="section">
   <h2>Announced Articles</h2>
   <div class="box">
-    {% if user_submissions|selectattr('published')|list|length > 0 %}
+    {% if user_submissions|selectattr('announced')|list|length > 0 %}
     <table class="table is-fullwidth is-hoverable">
       <tr>
         <th scope="col">Identifier</th>
@@ -102,7 +102,7 @@
         <th scope="col">Actions</th>
       </tr>
       {% for submission in user_submissions %}
-        {% if submission.published %}
+        {% if submission.announced %}
       <tr>
         <td>{{ submission.arxiv_id }}</td>
         <td><span class="tag is-link">{{ submission.primary_classification.category }}</span></td>
@@ -112,7 +112,7 @@
             {% for request in submission.active_user_requests %}
             <div class="tags has-addons">
               <span class="tag is-warning">{{ request.NAME }} {{ request.status }}</span>
-              <a href="{{ url_for('ui.cancel_request', submission_id=submission.submission_id, request_type=request.NAME.lower()) }}" class="tag is-danger">
+              <a href="{{ url_for('ui.cancel_request', submission_id=submission.submission_id, request_id=request.request_id) }}" class="tag is-danger">
                   <span class="icon">
                     <i class="fa fa-trash" aria-label="Delete"><span class="sr-only">Delete this submission</span></i>
                   </span>

--- a/submit/templates/submit/create.html
+++ b/submit/templates/submit/create.html
@@ -112,7 +112,7 @@
             {% for request in submission.active_user_requests %}
             <div class="tags has-addons">
               <span class="tag is-warning">{{ request.NAME }} {{ request.status }}</span>
-              <a href="{{ url_for('ui.cancel_request', submission_id=submission.submission_id, request_id=request.request_id) }}" class="tag is-danger">
+              <a href="{{ url_for('ui.cancel_request', submission_id=submission.submission_id, request_id=request.request_id) }}" class="tag button is-link is-small is-outlined" style="border: 0px; text-decoration: none;">
                   <span class="icon">
                     <i class="fa fa-trash" aria-label="Delete"><span class="sr-only">Delete this submission</span></i>
                   </span>

--- a/submit/templates/submit/jref.html
+++ b/submit/templates/submit/jref.html
@@ -133,7 +133,7 @@
             <div class="message-body">
             <p>
               <span class="icon has-text-link"><i class="fa fa-info-circle"></i></span>
-              When an article is published, the author may wish to
+              When an article is announced, the author may wish to
               indicate this in the abstract listing for the article. For
               this reason, the journal reference and DOI (Digital Object
               Identifier) fields are provided for articles.

--- a/submit/templates/submit/status.html
+++ b/submit/templates/submit/status.html
@@ -8,8 +8,8 @@
   layout that communicates what's going on with a user's submission.
 </p>
 
-<a href="{{ url_for('ui.publish', submission_id=submission_id) }}" class="button is-link">
-  Click me to set the submission to published which cannot be undone and is for testing purposes only
+<a href="{{ url_for('ui.announce', submission_id=submission_id) }}" class="button is-link">
+  Click me to set the submission to announced which cannot be undone and is for testing purposes only
 </a>
 
 <pre>

--- a/submit/templates/submit/withdraw.html
+++ b/submit/templates/submit/withdraw.html
@@ -13,7 +13,7 @@
 
 {% block content %}
   <h1 class="title">Withdraw article</h1>
-
+  {{ submission.user_requests }}
   {% if require_confirmation and not confirmed %}
   <div class="notification is-info">
     <p>This preview shows the abstract page as it will be updated. Please
@@ -90,7 +90,7 @@
               <p>
                 Articles that have been announced and made public cannot be
                 completely removed. However, you may submit a withdrawal
-                notification for your article. Previously published versions of this article will still be publicly available.
+                notification for your article. Previously announced versions of this article will still be publicly available.
               </p>
             </div>
           {% endif %}

--- a/submit/templates/submit/withdraw.html
+++ b/submit/templates/submit/withdraw.html
@@ -13,7 +13,7 @@
 
 {% block content %}
   <h1 class="title">Withdraw article</h1>
-  {{ submission.user_requests }}
+
   {% if require_confirmation and not confirmed %}
   <div class="notification is-info">
     <p>This preview shows the abstract page as it will be updated. Please

--- a/submit/tests/test_workflow.py
+++ b/submit/tests/test_workflow.py
@@ -433,7 +433,7 @@ class TestJREFWorkflow(TestCase):
             # announced!
             db_submission = session.query(classic.models.Submission) \
                 .get(self.submission.submission_id)
-            db_submission.status = classic.models.Submission.announced
+            db_submission.status = classic.models.Submission.ANNOUNCED
             db_document = classic.models.Document(paper_id='1234.5678')
             db_submission.doc_paper_id = '1234.5678'
             db_submission.document = db_document
@@ -563,7 +563,7 @@ class TestWithdrawalWorkflow(TestCase):
             # announced!
             db_submission = session.query(classic.models.Submission) \
                 .get(self.submission.submission_id)
-            db_submission.status = classic.models.Submission.announced
+            db_submission.status = classic.models.Submission.ANNOUNCED
             db_document = classic.models.Document(paper_id='1234.5678')
             db_submission.doc_paper_id = '1234.5678'
             db_submission.document = db_document

--- a/submit/tests/test_workflow.py
+++ b/submit/tests/test_workflow.py
@@ -387,7 +387,7 @@ class TestJREFWorkflow(TestCase):
         self.headers = {'Authorization': self.token}
         self.client = self.app.test_client()
 
-        # Create and publish a submission.
+        # Create and announce a submission.
         with self.app.app_context():
             classic.create_all()
             session = classic.current_session()
@@ -430,10 +430,10 @@ class TestJREFWorkflow(TestCase):
                 FinalizeSubmission(creator=self.user)
             )
 
-            # Published!
+            # announced!
             db_submission = session.query(classic.models.Submission) \
                 .get(self.submission.submission_id)
-            db_submission.status = classic.models.Submission.PUBLISHED
+            db_submission.status = classic.models.Submission.announced
             db_document = classic.models.Document(paper_id='1234.5678')
             db_submission.doc_paper_id = '1234.5678'
             db_submission.document = db_document
@@ -517,7 +517,7 @@ class TestWithdrawalWorkflow(TestCase):
         self.headers = {'Authorization': self.token}
         self.client = self.app.test_client()
 
-        # Create and publish a submission.
+        # Create and announce a submission.
         with self.app.app_context():
             classic.create_all()
             session = classic.current_session()
@@ -560,10 +560,10 @@ class TestWithdrawalWorkflow(TestCase):
                 FinalizeSubmission(creator=self.user)
             )
 
-            # Published!
+            # announced!
             db_submission = session.query(classic.models.Submission) \
                 .get(self.submission.submission_id)
-            db_submission.status = classic.models.Submission.PUBLISHED
+            db_submission.status = classic.models.Submission.announced
             db_document = classic.models.Document(paper_id='1234.5678')
             db_submission.doc_paper_id = '1234.5678'
             db_submission.document = db_document
@@ -586,7 +586,7 @@ class TestWithdrawalWorkflow(TestCase):
         return token
 
     def test_request_withdrawal(self):
-        """User requests withdrawal of a published submission."""
+        """User requests withdrawal of a announced submission."""
         # Get the JREF page.
         endpoint = f'/{self.submission_id}/withdraw'
         response = self.client.get(endpoint, headers=self.headers)

--- a/submit/util.py
+++ b/submit/util.py
@@ -115,7 +115,7 @@ def apply_cross(submission_id: int) -> None:
     i = events.services.classic._get_head_idx(dbss)
     for dbs in dbss[:i]:
         if dbs.is_crosslist():
-            dbs.status = events.services.classic.models.Submission.announced
+            dbs.status = events.services.classic.models.Submission.ANNOUNCED
             session.add(dbs)
             session.commit()
 
@@ -139,7 +139,7 @@ def apply_withdrawal(submission_id: int) -> None:
     i = events.services.classic._get_head_idx(dbss)
     for dbs in dbss[:i]:
         if dbs.is_withdrawal():
-            dbs.status = events.services.classic.models.Submission.announced
+            dbs.status = events.services.classic.models.Submission.ANNOUNCED
             session.add(dbs)
             session.commit()
 

--- a/submit/util.py
+++ b/submit/util.py
@@ -76,14 +76,13 @@ def tidy_filesize(size: int) -> str:
 
 
 # TODO: remove me!
-def publish_submission(submission_id: int) -> None:
+def announce_submission(submission_id: int) -> None:
     """WARNING WARNING WARNING this is for testing purposes only."""
     dbss = events.services.classic._get_db_submission_rows(submission_id)
-    i = events.services.classic._get_head_idx(dbss)
-    head = dbss[i]
+    head = sorted([o for o in dbss if o.is_new_version()], key=lambda o: o.submission_id)[-1]
     session = events.services.classic.current_session()
-    if not head.is_published():
-        head.status = events.services.classic.models.Submission.PUBLISHED
+    if not head.is_announced():
+        head.status = events.services.classic.models.Submission.ANNOUNCED
     if head.document is None:
         paper_id = datetime.now().strftime('%s')[-4:] \
             + "." \
@@ -102,7 +101,7 @@ def place_on_hold(submission_id: int) -> None:
     i = events.services.classic._get_head_idx(dbss)
     head = dbss[i]
     session = events.services.classic.current_session()
-    if head.is_published() or head.is_on_hold():
+    if head.is_announced() or head.is_on_hold():
         return
     head.status = events.services.classic.models.Submission.ON_HOLD
     session.add(head)
@@ -116,7 +115,7 @@ def apply_cross(submission_id: int) -> None:
     i = events.services.classic._get_head_idx(dbss)
     for dbs in dbss[:i]:
         if dbs.is_crosslist():
-            dbs.status = events.services.classic.models.Submission.PUBLISHED
+            dbs.status = events.services.classic.models.Submission.announced
             session.add(dbs)
             session.commit()
 
@@ -140,7 +139,7 @@ def apply_withdrawal(submission_id: int) -> None:
     i = events.services.classic._get_head_idx(dbss)
     for dbs in dbss[:i]:
         if dbs.is_withdrawal():
-            dbs.status = events.services.classic.models.Submission.PUBLISHED
+            dbs.status = events.services.classic.models.Submission.announced
             session.add(dbs)
             session.commit()
 

--- a/uwsgi.ini
+++ b/uwsgi.ini
@@ -11,3 +11,4 @@ master = true
 ugreen = true
 uid = nobody
 stats = /tmp/stats.socket
+buffer-size = 65535


### PR DESCRIPTION
Tweaked the slug when there is an open cross-list or withdrawal request:

![image](https://user-images.githubusercontent.com/3451594/54784241-bb21b880-4bf9-11e9-80a2-dc58d3b71493.png)

Clicking the trash-can asks for confirmation:

![image](https://user-images.githubusercontent.com/3451594/54784284-d4c30000-4bf9-11e9-914b-449461c7b362.png)

et voila!

![image](https://user-images.githubusercontent.com/3451594/54784299-de4c6800-4bf9-11e9-98ab-59ee48734a03.png)

