### PR TITLE
ARXIVNG-1365 add links to tex help

### DIFF
--- a/submit/config.py
+++ b/submit/config.py
@@ -108,7 +108,9 @@ URLS = [
     ("clickthrough", "/ct?url=<url>&v=<v>", BASE_SERVER),
     ("help_endorse", "/help/endorsement", BASE_SERVER),
     ("help_replace", "/help/replace", BASE_SERVER),
-    ("help_version", "/help/replace#versions", BASE_SERVER)
+    ("help_version", "/help/replace#versions", BASE_SERVER),
+    ("help_mistakes", "/help/faq/mistakes", BASE_SERVER),
+    ("help_texprobs", "/help/faq/texprobs", BASE_SERVER)
 ]
 """
 URLs for external services, for use with :func:`flask.url_for`.

--- a/submit/templates/submit/file_process.html
+++ b/submit/templates/submit/file_process.html
@@ -57,7 +57,7 @@
             <li>process your upload after corrections</li>
           </ul>
           <p class="has-text-centered"><a class="button is-link" href="{{ url_for('ui.file_upload', submission_id=submission_id) }}">Go back to Upload Files</a></p>
-          <p class="has-text-centered"><a class="button" href="#help">Help: Common TeX Errors</a></p>
+          <p class="has-text-centered"><a class="button" href="{{ url_for('help_mistakes') }}">Help: Common TeX Errors</a></p>
         </div>
       </div>
 
@@ -72,6 +72,12 @@
             <li>Be sure to <span class="has-text-weight-bold">check the compiled preview carefully</span> for any undesired artifacts or errors - especially references, figures, and captions.</li>
             <li><span class="has-text-weight-bold">Check the compiler log</span> for warnings and errors.</li>
           </ul>
+          <p class="has-text-centered">
+            <a class="button is-link" href="{{ url_for('ui.file_preview', submission_id=submission_id) }}" target="_blank" title="PDF preview opens in a new tab">
+              <span>View PDF</span> <span class="icon"><i class="fa fa-external-link"></i></span>
+            </a>
+          </p>
+          <p class="has-text-centered"><a class="button" href="{{ url_for('help_texprobs') }}">Help: TeX Rendering Problems</a></p>
         </div>
       </div>
 


### PR DESCRIPTION
Straightforward and simple - adds `/help/faq/mistakes` and `/help/faq/texprobs` to config.py and links to the appropriate place:
Completed With Warnings gets a link to `texprobs`
Processing Failed gets a link to `mistakes`

Wasn't able to generate a screenshot for "Completed With Warnings", but noticed that we didn't have a view-PDF link (in theory, the PDF does get generated but we expect that it has rendering issues...right?). Added that plus the button-styled link for TeX rendering problems.

## Screenshot: compile failure
![Screen Shot 2019-03-29 at 11 29 40 AM](https://user-images.githubusercontent.com/17456668/55244340-685a8900-5217-11e9-9142-7f64cd9b67dd.png)
