### PR TITLE
ARXIVNG-2034 add metadata help bubbles

### DIFF
--- a/submit/templates/submit/add_metadata.html
+++ b/submit/templates/submit/add_metadata.html
@@ -8,7 +8,9 @@
   {% with field = form.title %}
   <div class="field">
     <div class="control">
-      <label class="label">{{ field.label.text }} <span class="icon has-text-link"><i class="fa fa-question-circle"></i></span></label>
+      <label class="label">{{ field.label.text }} <a href="{{ url_for('help_metadata') }}" class="help-bubble">
+        <i class="fa fa-question-circle is-info"></i>
+        <div class="bubble-text">Unicode, TeX accent characters, and MathJax are supported. Click for detailed information.</div></a></label>
       {% if field.errors %}
         <div class="help is-danger">
           {% for error in field.errors %}
@@ -33,7 +35,9 @@
   {% with field = form.authors_display %}
   <div class="field">
     <div class="control">
-      <label class="label">{{ field.label.text }} <span class="icon has-text-link"><i class="fa fa-question-circle"></i></span></label>
+      <label class="label">{{ field.label.text }} <a href="{{ url_for('help_metadata') }}" class="help-bubble">
+        <i class="fa fa-question-circle is-info"></i>
+        <div class="bubble-text">Click for detailed information on author name formatting.</div></a></label>
       {% if field.errors %}
         <div class="help is-danger">
           {% for error in field.errors %}
@@ -47,7 +51,7 @@
       </p>
       {% endif %}
       {% if field.errors %}
-        {{ field(class="input is-danger")|safe }}
+        {{ field(class="textarea is-danger")|safe }}
       {% else %}
         {{ field(class="textarea")|safe }}
       {% endif %}
@@ -58,7 +62,9 @@
   {% with field = form.abstract %}
   <div class="field">
     <div class="control">
-      <label class="label">{{ field.label.text }} <span class="icon has-text-link"><i class="fa fa-question-circle"></i></span></label>
+      <label class="label">{{ field.label.text }} <a href="{{ url_for('help_metadata') }}" class="help-bubble">
+        <i class="fa fa-question-circle is-info"></i>
+        <div class="bubble-text">Unicode, TeX accent characters, and MathJax are supported. Click for detailed information.</div></a></label>
       {% if field.errors %}
         <div class="help is-danger">
           {% for error in field.errors %}
@@ -72,7 +78,7 @@
       </p>
       {% endif %}
       {% if field.errors %}
-        {{ field(class="input is-danger")|safe }}
+        {{ field(class="textarea is-danger")|safe }}
       {% else %}
         {{ field(class="textarea")|safe }}
       {% endif %}
@@ -83,7 +89,9 @@
   {% with field = form.comments %}
   <div class="field">
     <div class="control">
-      <label class="label">{{ field.label.text }} <span class="icon has-text-link"><i class="fa fa-question-circle"></i></span></label>
+      <label class="label">{{ field.label.text }} <a href="{{ url_for('help_metadata') }}" class="help-bubble">
+        <i class="fa fa-question-circle is-info"></i>
+        <div class="bubble-text">Unicode, TeX accent characters. and MathJax are supported. Click for detailed information.</div></a></label>
       {% if field.errors %}
         <div class="help is-danger">
           {% for error in field.errors %}

--- a/submit/templates/submit/add_optional_metadata.html
+++ b/submit/templates/submit/add_optional_metadata.html
@@ -6,131 +6,151 @@
 {% block within_content %}
 <form method="POST" action="{{ url_for('ui.add_optional_metadata', submission_id=submission_id) }}">
   {{ form.csrf_token }}
-
-  {% with field = form.doi %}
-  <div class="field is-short-field">
-    <div class="control">
-      <label class="label">{{ field.label.text }} <span class="icon has-text-link"><i class="fa fa-question-circle"></i></span></label>
-      {% if field.errors %}
-        <div class="help is-danger">
-          {% for error in field.errors %}
-              {{ error }}
-          {% endfor %}
+  <div class="columns">
+    <div class="column">
+      {% with field = form.doi %}
+      <div class="field is-short-field">
+        <div class="control">
+          <label class="label">{{ field.label.text }} <a href="{{ url_for('help_metadata') }}" class="help-bubble">
+            <i class="fa fa-question-circle is-info"></i>
+            <div class="bubble-text">This field is <strong>only</strong> for a DOI. Separate multiple DOIs with a space.</div></a></label>
+          {% if field.errors %}
+            <div class="help is-danger">
+              {% for error in field.errors %}
+                  {{ error }}
+              {% endfor %}
+            </div>
+          {% endif %}
+          {% if field.description %}
+          <p class="help has-text-grey is-marginless">
+            {{ field.description|safe }}
+          </p>
+          {% endif %}
+          {% if field.errors %}
+            {{ field(class="input is-danger")|safe }}
+          {% else %}
+            {{ field(class="input")|safe }}
+          {% endif %}
         </div>
-      {% endif %}
-      {% if field.description %}
-      <p class="help has-text-grey is-marginless">
-        {{ field.description|safe }}
-      </p>
-      {% endif %}
-      {% if field.errors %}
-        {{ field(class="input is-danger")|safe }}
-      {% else %}
-        {{ field(class="input")|safe }}
-      {% endif %}
-    </div>
-  </div>
-  {% endwith %}
+      </div>
+      {% endwith %}
 
-  {% with field = form.journal_ref %}
-  <div class="field is-short-field">
-    <div class="control">
-      <label class="label">{{ field.label.text }} <span class="icon has-text-link"><i class="fa fa-question-circle"></i></span></label>
-      {% if field.errors %}
-        <div class="help is-danger">
-          {% for error in field.errors %}
-              {{ error }}
-          {% endfor %}
+      {% with field = form.journal_ref %}
+      <div class="field is-short-field">
+        <div class="control">
+          <label class="label">{{ field.label.text }} <a href="{{ url_for('help_metadata') }}" class="help-bubble">
+            <i class="fa fa-question-circle is-info"></i>
+            <div class="bubble-text">Click for a detailed help page on journal reference formatting.</div></a></label>
+          {% if field.errors %}
+            <div class="help is-danger">
+              {% for error in field.errors %}
+                  {{ error }}
+              {% endfor %}
+            </div>
+          {% endif %}
+          {% if field.description %}
+          <p class="help has-text-grey is-marginless">
+            {{ field.description|safe }}
+          </p>
+          {% endif %}
+          {% if field.errors %}
+            {{ field(class="input is-danger")|safe }}
+          {% else %}
+            {{ field(class="input")|safe }}
+          {% endif %}
         </div>
-      {% endif %}
-      {% if field.description %}
-      <p class="help has-text-grey is-marginless">
-        {{ field.description|safe }}
-      </p>
-      {% endif %}
-      {% if field.errors %}
-        {{ field(class="input is-danger")|safe }}
-      {% else %}
-        {{ field(class="input")|safe }}
-      {% endif %}
-    </div>
-  </div>
-  {% endwith %}
+      </div>
+      {% endwith %}
 
-  {% with field = form.report_num %}
-  <div class="field is-short-field">
-    <div class="control">
-      <label class="label">{{ field.label.text }} <span class="icon has-text-link"><i class="fa fa-question-circle"></i></span></label>
-      {% if field.errors %}
-        <div class="help is-danger">
-          {% for error in field.errors %}
-              {{ error }}
-          {% endfor %}
+      {% with field = form.report_num %}
+      <div class="field is-short-field">
+        <div class="control">
+          <label class="label">{{ field.label.text }} <a href="{{ url_for('help_metadata') }}" class="help-bubble">
+            <i class="fa fa-question-circle is-info"></i>
+            <div class="bubble-text">This field is <strong>only</strong> for an institution-supplied number. Click for a detailed help page.</div></a></label>
+          {% if field.errors %}
+            <div class="help is-danger">
+              {% for error in field.errors %}
+                  {{ error }}
+              {% endfor %}
+            </div>
+          {% endif %}
+          {% if field.description %}
+          <p class="help has-text-grey is-marginless">
+            {{ field.description|safe }}
+          </p>
+          {% endif %}
+          {% if field.errors %}
+            {{ field(class="input is-danger")|safe }}
+          {% else %}
+            {{ field(class="input")|safe }}
+          {% endif %}
         </div>
-      {% endif %}
-      {% if field.description %}
-      <p class="help has-text-grey is-marginless">
-        {{ field.description|safe }}
-      </p>
-      {% endif %}
-      {% if field.errors %}
-        {{ field(class="input is-danger")|safe }}
-      {% else %}
-        {{ field(class="input")|safe }}
-      {% endif %}
-    </div>
-  </div>
-  {% endwith %}
+      </div>
+      {% endwith %}
 
-  {% with field = form.acm_class %}
-  <div class="field is-short-field">
-    <div class="control">
-      <label class="label">{{ field.label.text }} <span class="icon has-text-link"><i class="fa fa-question-circle"></i></span></label>
-      {% if field.errors %}
-        <div class="help is-danger">
-          {% for error in field.errors %}
-              {{ error }}
-          {% endfor %}
+      {% with field = form.acm_class %}
+      <div class="field is-short-field">
+        <div class="control">
+          <label class="label">{{ field.label.text }} <a href="{{ url_for('help_metadata') }}" class="help-bubble">
+            <i class="fa fa-question-circle is-info"></i>
+            <div class="bubble-text">For classifications in CS only. Click for a detailed help page.</div></a></label>
+          {% if field.errors %}
+            <div class="help is-danger">
+              {% for error in field.errors %}
+                  {{ error }}
+              {% endfor %}
+            </div>
+          {% endif %}
+          {% if field.description %}
+          <p class="help has-text-grey is-marginless">
+            {{ field.description|safe }}
+          </p>
+          {% endif %}
+          {% if field.errors %}
+            {{ field(class="input is-danger")|safe }}
+          {% else %}
+            {{ field(class="input")|safe }}
+          {% endif %}
         </div>
-      {% endif %}
-      {% if field.description %}
-      <p class="help has-text-grey is-marginless">
-        {{ field.description|safe }}
-      </p>
-      {% endif %}
-      {% if field.errors %}
-        {{ field(class="input is-danger")|safe }}
-      {% else %}
-        {{ field(class="input")|safe }}
-      {% endif %}
-    </div>
-  </div>
-  {% endwith %}
+      </div>
+      {% endwith %}
 
-  {% with field = form.msc_class %}
-  <div class="field is-short-field">
-    <div class="control">
-      <label class="label">{{ field.label.text }} <span class="icon has-text-link"><i class="fa fa-question-circle"></i></span></label>
-      {% if field.errors %}
-        <div class="help is-danger">
-          {% for error in field.errors %}
-              {{ error }}
-          {% endfor %}
+      {% with field = form.msc_class %}
+      <div class="field is-short-field">
+        <div class="control">
+          <label class="label">{{ field.label.text }} <a href="{{ url_for('help_metadata') }}" class="help-bubble">
+            <i class="fa fa-question-circle is-info"></i>
+            <div class="bubble-text">For classifications in math only. Click for a detailed help page.</div></a></label>
+          {% if field.errors %}
+            <div class="help is-danger">
+              {% for error in field.errors %}
+                  {{ error }}
+              {% endfor %}
+            </div>
+          {% endif %}
+          {% if field.description %}
+          <p class="help has-text-grey is-marginless">
+            {{ field.description|safe }}
+          </p>
+          {% endif %}
+          {% if field.errors %}
+            {{ field(class="input is-danger")|safe }}
+          {% else %}
+            {{ field(class="input")|safe }}
+          {% endif %}
         </div>
-      {% endif %}
-      {% if field.description %}
-      <p class="help has-text-grey is-marginless">
-        {{ field.description|safe }}
-      </p>
-      {% endif %}
-      {% if field.errors %}
-        {{ field(class="input is-danger")|safe }}
-      {% else %}
-        {{ field(class="input")|safe }}
-      {% endif %}
-    </div>
+      </div>
+      {% endwith %}
+      </div>
+      <div class="column">
+        <div class="message is-info">
+          <div class="message-body">
+            <p><span class="icon has-text-link"><i class="fa fa-info-circle"></i></span>If this article has not yet been published elsewhere, this information can be <a href="{{ ('help_jref') }}">added at any later time</a> without submitting a new version.</p>
+          </div>
+        </div>
+      </div>
   </div>
-  {% endwith %}
 
   {{ submit_macros.submit_nav(submission_id) }}
 </form>


### PR DESCRIPTION
Erick: once this is merged, I'll be done poking at submissionUI until you give the OK. 
Review for code and content. Wasn't quite sure what to put in the bubbles, they're all a little bit lame in the "click for help" language.

I added the help message about having a jref option on the optional metadata page, too - felt like that note was missing.

As mentioned in Slack, we'll need an edited docs page for the help on metadata. I can get it started by cloning the /help/metadata page? Am guessing that the content can stay the same except for the technical-support part of what input can be accepted.

## Screenshots
![Screen Shot 2019-04-02 at 4 15 29 PM](https://user-images.githubusercontent.com/17456668/55433445-5bb19a00-5563-11e9-96f2-01bfa33d0b25.png)

![Screen Shot 2019-04-02 at 4 16 31 PM](https://user-images.githubusercontent.com/17456668/55433453-60764e00-5563-11e9-8360-e38729576282.png)
