### PR TITLE
ARXIVNG-2031 add layout template for admin functions

### DIFF
--- a/submit/templates/submit/admin_macros.html
+++ b/submit/templates/submit/admin_macros.html
@@ -15,10 +15,10 @@
         </div>
         <div class="field">
           <div class="control">
-            <!-- #TODO needs Bulma extension installed to have the styled toggle, switch to is-success for unchecked version. If possible, style label text into solid area of toggle. -->
+            <!-- #TODO needs Bulma extension installed (preferably in base) to have the styled toggle, switch color to is-success for unchecked version. If possible, style label text into solid area of toggle. -->
             <input id="LockToggle" type="checkbox" name="LockToggle" class="switch is-rounded is-danger" checked="checked">
               <label for="LockToggle">LOCKED</label>
-            <span>Admin One 2019-04-20</span>
+            <span>{% user.fullname %} 2019-04-20</span>
           </div>
         </div>
       </div>

--- a/submit/templates/submit/admin_macros.html
+++ b/submit/templates/submit/admin_macros.html
@@ -1,0 +1,76 @@
+{% macro admin_upload(submission_id) %}
+  <section class="section box has-background-light">
+    <div class="columns">
+      <div class="column is-narrow has-text-centered">
+        <h2 class="is-uppercase">Admin</h2>
+        <div class="field">
+          <div class="control has-text-centered">
+            <a class="button is-outlined is-link" href="">Download current as .tar</a>
+          </div>
+        </div>
+        <div class="field">
+          <div class="control has-text-centered">
+            <a class="button is-outlined is-link" href="">Create checkpoint</a>
+          </div>
+        </div>
+        <div class="field">
+          <div class="control">
+            <!-- #TODO needs Bulma extension installed to have the styled toggle, switch to is-success for unchecked version. If possible, style label text into solid area of toggle. -->
+            <input id="LockToggle" type="checkbox" name="LockToggle" class="switch is-rounded is-danger" checked="checked">
+              <label for="LockToggle">LOCKED</label>
+            <span>Admin One 2019-04-20</span>
+          </div>
+        </div>
+      </div>
+      <div class="column">
+        <h3 class="is-size-5">Checkpoints</h3>
+        <div class="level has-background-white is-marginless" style="padding: 0.5em">
+          <div class="level-left">
+            <span class="level-item">
+              2019-04-11T09:57:00Z
+            </span>
+            <span class="level-item">
+              Title might be longer than this
+            </span>
+          </div>
+          <div class="level-right">
+            <div class="level-item">
+              <div class="field">
+                <div class="control">
+                  <a href="" class="button is-link is-outlined is-small">Make current</a>
+                  <a href="" class="button is-link is-outlined is-small">Download</a>
+                  <a href="" class="button is-link is-outlined is-small"><span class="icon">
+                    <i class="fa fa-trash"><span class="sr-only">Delete this checkpoint</span></i>
+                  </span></a>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="level has-background-grey-lighter is-marginless" style="padding: 0.5em">
+          <div class="level-left">
+            <span class="level-item">
+              2019-04-11T09:57:00Z
+            </span>
+            <span class="level-item">
+              Title might be longer than this
+            </span>
+          </div>
+          <div class="level-right">
+            <div class="level-item">
+              <div class="field">
+                <div class="control">
+                  <a href="" class="button is-link is-outlined is-small">Make current</a>
+                  <a href="" class="button is-link is-outlined is-small">Download</a>
+                  <a href="" class="button is-link is-outlined is-small"><span class="icon">
+                    <i class="fa fa-trash"><span class="sr-only">Delete this checkpoint</span></i>
+                  </span></a>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+{% endmacro %}


### PR DESCRIPTION
Adds the LAYOUT only (no functionality) for admin functions.

## Macro file generates output that looks like this:
![Screen Shot 2019-04-12 at 3 02 07 PM](https://user-images.githubusercontent.com/17456668/56060377-aafe8400-5d34-11e9-8180-6e0ec920cb1d.png)

In order to use the switch styling, arxiv-base will need to be updated with the inclusion of https://github.com/arXiv/arxiv-base/pull/126. The layout doesn't get super broken without it, you'll just see a simple checkbox instead of a switch.

## Draft design (Sketch) of the original idea:
![submission-admin-functions](https://user-images.githubusercontent.com/17456668/56060449-df724000-5d34-11e9-9491-fe5390eddca1.png)

(Note that white background buttons are tricky without losing the overlay, so I bailed on that idea and let them be transparent-background instead.)