### PR TITLE
Fix background color for fatal class.

### DIFF
--- a/submit/static/css/submit.css
+++ b/submit/static/css/submit.css
@@ -154,7 +154,7 @@ ol.file-tree > li ol li:first-child {
 
 .tex-fatal {
   background-color: #cd0200;
-  color: rgba 255, 255, 255, 1;
+  color: white;
   padding: 0 0.2em;
 }
 

--- a/submit/static/sass/submit.sass
+++ b/submit/static/sass/submit.sass
@@ -129,7 +129,7 @@ ol.file-tree
 
 .tex-fatal
   background-color: rgba(205, 2, 0, 1)
-  color: rgba (255, 255, 255, 1)
+  color: rgba(255,255,255,1)
   padding: 0 0.2em
 
 /* Classes for responsive bubble-style progress bar */


### PR DESCRIPTION
Trivial one line change to remove extra space in color specification. Font color for the fatal class is now white.
