### PR TITLE
ARXIVNG-2214: Replace non-existent help tips with link to existing submission help pages

### DIFF
--- a/submit/templates/submit/manage_submissions.html
+++ b/submit/templates/submit/manage_submissions.html
@@ -11,11 +11,7 @@
         {{ form.csrf_token }}
         <button name="new" class="button is-large is-link" value="new" aria-label="Create New Submission" style="margin-bottom: 1.5rem;">Start a New Submission</button>
       </form>
-      <h3>Helpful Tips</h3>
-      <ul style="list-style: none;">
-        <li><a href="#">Pre-Submission Checklist</a></li>
-        <li><a href="#">List of Included TeX Packages</a></li>
-      </ul>
+      <h3><a href="https://arxiv.org/help#submission-and-revision">Submission Help Pages</a></h3>
     </div>
   </div>
   <div class="column">


### PR DESCRIPTION
This minor Submission UI change replaces non-existent help tips with link to existing submission help pages.

