### PR TITLE
Request PDF from FileManager for PDF-only submission, not from compiler

### DIFF
--- a/submit/controllers/process.py
+++ b/submit/controllers/process.py
@@ -305,8 +305,7 @@ def file_preview(params, session: Session, submission_id: int, token: str,
                  **kwargs) -> Response:
     submitter, client = user_and_client_from_session(session)
     submission, submission_events = load_submission(submission_id)
-    if (submission.source_content.source_format == SubmissionContent.Format.PDF
-        or submission.source_content.source_format == SubmissionContent.Format.PDFTEX):
+    if (submission.source_content.source_format == SubmissionContent.Format.PDF):
         subfiles = FileManager.get_upload_status(
             submission.source_content.identifier,
             token)

--- a/submit/controllers/process.py
+++ b/submit/controllers/process.py
@@ -309,9 +309,12 @@ def file_preview(params, session: Session, submission_id: int, token: str,
         subfiles = FileManager.get_upload_status(
             submission.source_content.identifier,
             token)
-        pdf_name = next(( file.name for file in subfiles.files if file.file_type=='PDF'))
-        (pdf_dload,rh) = FileManager.get_file_content(submission.source_content.identifier,
-                                            pdf_name, token)
+        pdf_name = next((file.name
+                         for file in subfiles.files
+                         if file.file_type == 'PDF'))
+        pdf_dload, rh = \
+            FileManager.get_file_content(submission.source_content.identifier,
+                                         pdf_name, token)
         headers = {'Content-Type': 'application/pdf'}
         return io.BytesIO(pdf_dload.read()), status.OK, headers
     else:

--- a/submit/controllers/process.py
+++ b/submit/controllers/process.py
@@ -305,7 +305,7 @@ def file_preview(params, session: Session, submission_id: int, token: str,
                  **kwargs) -> Response:
     submitter, client = user_and_client_from_session(session)
     submission, submission_events = load_submission(submission_id)
-    if (submission.source_content.source_format == SubmissionContent.Format.PDF):
+    if submission.source_content.source_format == SubmissionContent.Format.PDF:
         subfiles = FileManager.get_upload_status(
             submission.source_content.identifier,
             token)

--- a/submit/controllers/process.py
+++ b/submit/controllers/process.py
@@ -314,8 +314,7 @@ def file_preview(params, session: Session, submission_id: int, token: str,
         (pdf_dload,rh) = FileManager.get_file_content(submission.source_content.identifier,
                                             pdf_name, token)
         headers = {'Content-Type': 'application/pdf'}
-        raise "TODO: ARXIVNG-2217 get pdf_dload into flask response"
-        #return dl.read(), status.OK, headers
+        return io.BytesIO(pdf_dload.read()), status.OK, headers
     else:
         prod = Compiler.get_product(submission.source_content.identifier,
                                     submission.source_content.checksum, token)

--- a/submit/controllers/process.py
+++ b/submit/controllers/process.py
@@ -302,7 +302,7 @@ def _get_log(identifier: str, checksum: str, token: str) -> dict:
 
 
 def file_preview(params, session: Session, submission_id: int, token: str,
-                 **kwargs) -> Response:
+                 **kwargs) -> Tuple[io.BytesIO, int, Dict[str, str]]:
     submitter, client = user_and_client_from_session(session)
     submission, submission_events = load_submission(submission_id)
     if submission.source_content.source_format == SubmissionContent.Format.PDF:

--- a/submit/controllers/process.py
+++ b/submit/controllers/process.py
@@ -62,6 +62,7 @@ from arxiv.submission.services.compiler import Compiler
 from arxiv.submission import ConfirmCompiledPreview
 from arxiv.submission.domain.compilation import Compilation
 from arxiv.submission.domain.submission import Compilation, SubmissionContent
+from ..services import FileManager
 from ..util import load_submission
 from .util import validate_command, user_and_client_from_session
 
@@ -304,10 +305,22 @@ def file_preview(params, session: Session, submission_id: int, token: str,
                  **kwargs) -> Response:
     submitter, client = user_and_client_from_session(session)
     submission, submission_events = load_submission(submission_id)
-    prod = Compiler.get_product(submission.source_content.identifier,
-                                submission.source_content.checksum, token)
-    headers = {'Content-Type': prod.content_type}
-    return prod.stream, status.OK, headers
+    if (submission.source_content.source_format == SubmissionContent.Format.PDF
+        or submission.source_content.source_format == SubmissionContent.Format.PDFTEX):
+        subfiles = FileManager.get_upload_status(
+            submission.source_content.identifier,
+            token)
+        pdf_name = next(( file.name for file in subfiles.files if file.file_type=='PDF'))
+        (pdf_dload,rh) = FileManager.get_file_content(submission.source_content.identifier,
+                                            pdf_name, token)
+        headers = {'Content-Type': 'application/pdf'}
+        raise "TODO: ARXIVNG-2217 get pdf_dload into flask response"
+        #return dl.read(), status.OK, headers
+    else:
+        prod = Compiler.get_product(submission.source_content.identifier,
+                                    submission.source_content.checksum, token)
+        headers = {'Content-Type': prod.content_type}
+        return prod.stream, status.OK, headers
 
 
 def compilation_log(params, session: Session, submission_id: int, token: str,


### PR DESCRIPTION
This change to process.py makes it so a PDF submission will get the PDF to preview from the FileManager, not the compiler. 

While change this fixes the issue, it may be better to have the Compiler service respond with a redirect to the FileManager when the product is requested. This would prevent downstream services from containing any knowledge about how different types of submissions are turned into PDFs. 

@DavidLFielding Is it correct to handle PDFTEX submission types this way?

I plan to squash this due to the WIP commit.