### PR TITLE
Changes help text on license page about other CC licenses.

### DIFF
--- a/submit/templates/submit/license.html
+++ b/submit/templates/submit/license.html
@@ -43,7 +43,7 @@
         </div>
         <div class="message-body">
           <p>See the <a href="{{ url_for('help_license') }}">Discussion of licenses</a> for more information.</p>
-          <p>If none of these licenses apply, you may be able to indicate your license of choice in the article text.</p>
+          <p>If you wish to use a different CC license, then select arXiv's non-exclusive license to distribute in the arXiv and indicate the desired Creative Commons license in the article's full text.</p>
         </div>
       </div>
 


### PR DESCRIPTION
Change to text in html page.

Fixes https://github.com/arXiv/arxiv-submission-ui/issues/93
and
ARXIVNG-2222