### PR TITLE
Adds client side JS to control authorship inputs

### DIFF
--- a/submit/static/js/authorship.js
+++ b/submit/static/js/authorship.js
@@ -1,0 +1,20 @@
+/* Client side affects for authorship step
+   Enables or disables proxy confirmation checkbox based on not-author radio button. */
+var handle_not_author = function(e){ 
+  var proxy_checkbox = document.getElementById("proxy");
+  var not_author = document.getElementById("authorship-1");
+  if( not_author.checked ){
+    proxy_checkbox.disabled = false;
+  }else{
+    proxy_checkbox.checked = false;
+    proxy_checkbox.disabled = true;
+  }
+}
+
+window.addEventListener('DOMContentLoaded', (e) => {
+  var author = document.getElementById("authorship-0");
+  var not_author = document.getElementById("authorship-1");
+  not_author.onchange = handle_not_author;
+  author.onchange = handle_not_author;
+  handle_not_author(0);
+});

--- a/submit/static/js/authorship.js
+++ b/submit/static/js/authorship.js
@@ -1,4 +1,4 @@
-/* Client side affects for authorship step
+/* Client-side effects for authorship step
    Enables or disables proxy confirmation checkbox based on not-author radio button. */
 var handle_not_author = function(e){ 
   var proxy_checkbox = document.getElementById("proxy");

--- a/submit/templates/submit/authorship.html
+++ b/submit/templates/submit/authorship.html
@@ -1,5 +1,10 @@
 {% extends "submit/base.html" %}
 
+{% block addl_head %}
+{{super()}}
+  <script src="{{ url_for('static', filename='js/authorship.js') }}"></script>
+{% endblock addl_head %}
+ 
 {% block title -%}Confirm Authorship{%- endblock title %}
 
 {% block within_content %}

--- a/submit/templates/submit/base.html
+++ b/submit/templates/submit/base.html
@@ -4,7 +4,6 @@
 
 {% block addl_head %}
  <link rel="stylesheet" href="{{ url_for('static', filename='css/submit.css')}}" />
- <script src="{{ url_for('static', filename='js/filewidget.js') }}"></script>
  {% block extra_head %}{% endblock %}
 {% endblock addl_head %}
 

--- a/submit/templates/submit/file_upload.html
+++ b/submit/templates/submit/file_upload.html
@@ -1,5 +1,10 @@
 {% extends "submit/base.html" %}
 
+{% block addl_head %}
+{{super()}}
+ <script src="{{ url_for('static', filename='js/filewidget.js') }}"></script>
+{% endblock addl_head %}
+
 {% macro display_tree(key, item, even) %}
   {% if key %}
   <li class="{% if item.errors %}is-warning{% elif item.modified and item|just_updated %}is-success{% endif %} {% if even %}even{% endif %}">


### PR DESCRIPTION
Disables proxy checkbox when not-author radio button is not selected.

Fixes #125

One thing to note is that this removes filewidget.js from the base.html template and adds it to the file_upload.html. If filewidget.js is needed on other pages, let me know and I'll undo it. When searching the text of the templates, it looked like it was only used on file_upload.html.