### PR TITLE
ARXIVNG-2303 added APP_VERSION to config, plus base app tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,11 +11,11 @@ python:
 script:
   - pip install pipenv
   - pipenv install --dev --skip-lock
+  - pipenv run python -m tests.run_app_tests
   - pipenv run nose2 --with-coverage
-#  - ./tests/lint.sh
-  - ./tests/docstyle.sh
 after_success:
   - coveralls
+  - ./tests/docstyle.sh
   - if [ -z "$TRAVIS_TAG" ]; then
       echo "Not a tagged commit; skipping deploy.";
     else

--- a/submit/config.py
+++ b/submit/config.py
@@ -8,6 +8,9 @@ from typing import Optional
 import warnings
 from os import environ
 
+APP_VERSION = "0.1.1-alpha"
+"""The current version of this application."""
+
 NAMESPACE = environ.get('NAMESPACE')
 """Namespace in which this service is deployed; to qualify keys for secrets."""
 

--- a/tests/run_app_tests.py
+++ b/tests/run_app_tests.py
@@ -1,0 +1,12 @@
+"""This script runs the tests in :mod:`arxiv.base.app_tests`."""
+
+import unittest
+
+from arxiv.base.app_tests import *
+from submit.factory import create_ui_web_app
+
+app = create_ui_web_app()
+
+if __name__ == '__main__':
+    with app.app_context():
+        unittest.main()


### PR DESCRIPTION
This fixes #135 -- the ``null`` in the static URL was due to the absence of the ``APP_VERSION`` config param. I also added the app tests from ``arxiv.base`` to the test routine so that we are verifying this and other configuration issues related to base components/features that might arise.