### PR TITLE
ARXIVNG-2279: convert TeXisms to UTF in authors field in final preview

### DIFF
--- a/submit/templates/submit/final_preview.html
+++ b/submit/templates/submit/final_preview.html
@@ -31,7 +31,7 @@
   {{ macros.abs(
     arxiv_id,
     submission.metadata.title,
-    submission.metadata.authors_display,
+    submission.metadata.authors_display|tex2utf,
     submission.metadata.abstract,
     submission.created,
     submission.primary_classification.category,


### PR DESCRIPTION
Fixes #134 

What this does:
* adds the `tex2utf` filter to the authors field in the final preview
* provides display parity with the classic preview

What this does **not** do:
* provide search links on authors
* provide a collapsible author list if the list of extracted authors exceeds some number of authors

In short, the authors field in the final preview will not look exactly like the authors field in /abs. I know we've discussed wanting to have a preview that matches /abs as closely as possible, but this seems out of scope for this particular ticket; I can create new issues if we want to be sure to capture that.

<img width="1190" alt="Screenshot 2019-08-27 15 03 52" src="https://user-images.githubusercontent.com/746253/63801700-df876c80-c8de-11e9-8136-6cf9cb653927.png">


