### PR TITLE
Added info bubble for color key. [ARXIVNG-2495] David

### DIFF
--- a/submit/templates/submit/file_process.html
+++ b/submit/templates/submit/file_process.html
@@ -116,7 +116,7 @@
 
     {% if status and log_output %}
       <div class="is-size-7">
-        <p><strong>Key</strong></p>
+        <p><strong>Highlighting Key</strong></p>
         <code><span class="tex-fatal">Severe warnings/errors</span></code><br/>
         <code><span class="tex-danger">Important warnings</span></code><br/>
         <code><span class="tex-warning">General warnings/errors from packages</span></code><br/>
@@ -159,6 +159,24 @@
       <div class="level">
         <div class="level-left level-is-shrinkable">
           <h3>TeXLive Compiler Summary</h3>
+        </div>
+        <div>
+          <div class="help-bubble">
+            <i class="fa fa-question-circle is-info"> Highlighting Key</i>
+            <div class="bubble-text">
+              <div class="is-size-10">
+                <p><strong>Highlighting Key</strong></p>
+                <code><span class="tex-fatal">Severe warnings/errors</span></code><br/>
+                <code><span class="tex-danger">Important warnings</span></code><br/>
+                <code><span class="tex-warning">General warnings/errors from packages</span></code><br/>
+                <code><span class="tex-ignore">Unimportant warnings/errors</span></code><br/>
+                <code><span class="tex-success">Positive event</span></code><br/>
+                <code><span class="tex-info">Informational markup</span></code><br/>
+                <code><span class="tex-help">References to help documentation</span></code><br/>
+                <code><span class="tex-suggestion">Recommended solution</span></code><br/>
+              </div>
+            </div>
+          </div>
         </div>
         <div class="level-right">
           <a class="button" href="{{ url_for('ui.compilation_log', submission_id=submission_id) }}" target="_blank">


### PR DESCRIPTION
The PR adds a simple help bubble at the header/title element at the top of the autotext log text area [ARXIVNG-2495].

Color key was moved to below reprocess button. In certain cases this key is not available unless you scroll your page down to see it. This task was to investigate other options for displaying the color highlighting key. The info bubble seemed to be the best way to do this.

Stakeholders asked to keep both displays of highlighting key so key is available below reprocess button and as info bubble at top of autotex log text area.

This may be revised after addition user testing and evaluation.

[ARXIVNG-2495]: https://arxiv-org.atlassian.net/browse/ARXIVNG-2495

![Screen Shot 2019-09-09 at 12 22 21 PM](https://user-images.githubusercontent.com/2325384/64623602-38fb9b00-d3b7-11e9-8a3a-9b2ad8e56677.png)
