### PR TITLE
ARXIVNG-2787: Reduce size of converter image (Create image for each tree)

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ very large converter image that contains the complete set of all arXiv TeX trees
 At the current time you may configure a single converter image to compile TeX sources.
 
 The following TeX trees are available: TeX Live 2016 (most recent); TeX Live 2011;
-TeX Live 2009, teTeX 2, and teTeX 3. The teTeX 2 tree contains multiple local trees.
+TeX Live 2009; teTeX 2; and teTeX 3. The teTeX 2 tree contains multiple local trees.
 
 Set the CONVERTER_DOCKER_IMAGE environment variable to indicate the converter image
 you would like to select.

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Most converter images contain a single TeX tree (to reduce size) along with one
 very large converter image that contains the complete set of all arXiv TeX trees (14.5G).
 At the current time you may configure a single converter image to compile TeX sources.
 
-The Following TeX trees are available: TeX Live 2016 (most recent). TeX Live 2011,
+The following TeX trees are available: TeX Live 2016 (most recent); TeX Live 2011;
 TeX Live 2009, teTeX 2, and teTeX 3. The teTeX 2 tree contains multiple local trees.
 
 Set the CONVERTER_DOCKER_IMAGE environment variable to indicate the converter image

--- a/README.md
+++ b/README.md
@@ -107,7 +107,67 @@ When using the mock-compiler service you will get the same PDF and compilation l
 The idea behind the mock compiler service is to let you work through the entire submission process workflow
 without the hassle of installing the compiler service.
 
-## Quick start using full arXiv Compiler service (with actual TeX compilation)
+## Quick start using arXiv Compiler service (with actual TeX compilation)
+
+There are now multiple converter images that may be configured to compile TeX source.
+Most converter images contains a single TeX tree (to reduce size) along with one
+very large converter image that contains the complete set of all arXiv TeX trees (14.5G).
+At the current time you may configure a single converter image to compile TeX sources.
+
+The Following TeX trees are available: TeX Live 2016 (most recent). TeX Live 2011,
+TeX Live 2009, teTeX 2, and teTeX 3. The teTeX 2 tree contains multiple local trees.
+
+Set the CONVERTER_DOCKER_IMAGE environment variable to indicate the converter image
+you would like to select.
+
+Please check arXiv's ASW ECR repository for the current list of images.
+
+  All Trees: (14.5G) Contains all trees, submissions uses latest tree.
+    626657773168.dkr.ecr.us-east-1.amazonaws.com/arxiv/converter
+
+  TL2016: (7.9G) 2017-02-09
+    626657773168.dkr.ecr.us-east-1.amazonaws.com/arxiv/converter-2016
+
+  TL2011: (5.8G) 2011-12-06
+    626657773168.dkr.ecr.us-east-1.amazonaws.com/arxiv/converter-2011
+
+  TL2009: (4.9G) 2009-12-31
+    626657773168.dkr.ecr.us-east-1.amazonaws.com/arxiv/converter-2009
+
+  teTeX 3: (3.1G) 2006-11-02
+    626657773168.dkr.ecr.us-east-1.amazonaws.com/arxiv/converter-tetex-3
+
+  teTeX 2: (3.2G) Uses different binaries and texmf (local tree) versions: 2002-09-01, 2003-01-01, 2004-01-01
+    626657773168.dkr.ecr.us-east-1.amazonaws.com/arxiv/converter-tetex-2
+
+There are two ways to download and install the converter image: manual and automatic.
+
+The 'automated' method lets the compiler service download the converter image for you. If you set the environment
+variable 'CONVERTER_IMAGE_PULL' to 1 in the docker-compose.yml file under both the compiler-api: and
+the compiler-worker: sections, and then rebuild/up the compiler service, the compiler service will attempt to download
+the image from AWS in the event it does not find it locally. There will be a delay during startup while the converter image
+is being downloaded.
+
+The second method is to manually download the converter image(s) you need prior to starting up the
+submission UI. This will save time during startup.
+
+The 'CONVERTER_IMAGE_PULL' environment variables are now set to 1 (enabled) by default. You may still want to
+manually download the image to speed up startup. In the event you accidently remove the converter image the
+compiler service will simply download a fresh copy. This seems like a useful safety feature.
+
+In both cases you will need to configure your AWS credentials prior to attempting converter image download.
+
+To let compiler service download converter image simply set (include version number**)
+```bash
+export CONVERTER_DOCKER_IMAGE=626657773168.dkr.ecr.us-east-1.amazonaws.com/arxiv/converter-2009:0.1.0
+```
+To download manually execute the pull command with the appropriate converter image specification:
+```bash
+$ docker pull 626657773168.dkr.ecr.us-east-1.amazonaws.com/arxiv/converter:latest
+```
+
+** Compiler service seems to get confused when version number is not included. This will be fixed
+in a subsequent ticket whe time permits.
 
 ### AWS Credentials
 First, you will need credentials to AWS ECR to get the converter docker

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ without the hassle of installing the compiler service.
 ## Quick start using arXiv Compiler service (with actual TeX compilation)
 
 There are now multiple converter images that may be configured to compile TeX source.
-Most converter images contains a single TeX tree (to reduce size) along with one
+Most converter images contain a single TeX tree (to reduce size) along with one
 very large converter image that contains the complete set of all arXiv TeX trees (14.5G).
 At the current time you may configure a single converter image to compile TeX sources.
 

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ compiler service will simply download a fresh copy. This seems like a useful saf
 
 In both cases you will need to configure your AWS credentials prior to attempting converter image download.
 
-To let compiler service download converter image simply set (include version number**)
+In order to let the compiler service download a converter image simply set (including version number**):
 ```bash
 export CONVERTER_DOCKER_IMAGE=626657773168.dkr.ecr.us-east-1.amazonaws.com/arxiv/converter-2009:0.1.0
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -84,7 +84,7 @@ services:
       REDIS_ENDPOINT: "submission-ui-redis"
       # CONVERTER_DOCKER_IMAGE: "626657773168.dkr.ecr.us-east-1.amazonaws.com/arxiv/converter:0.9"
       CONVERTER_DOCKER_IMAGE: "${CONVERTER_DOCKER_IMAGE}"
-      CONVERTER_IMAGE_PULL: 0
+      CONVERTER_IMAGE_PULL: 1
       DIND_SOURCE_ROOT: "${DIND_SOURCE_ROOT}"
       AWS_S3_REGION_NAME: "us-east-1"
       AWS_SECRET_ACCESS_KEY: "${AWS_SECRET_ACCESS_KEY}"
@@ -130,7 +130,7 @@ services:
       REDIS_ENDPOINT: "submission-ui-redis"
     # CONVERTER_DOCKER_IMAGE: "626657773168.dkr.ecr.us-east-1.amazonaws.com/arxiv/converter:0.9"
       CONVERTER_DOCKER_IMAGE: "${CONVERTER_DOCKER_IMAGE}"
-      CONVERTER_IMAGE_PULL: 0
+      CONVERTER_IMAGE_PULL: 1
       DIND_SOURCE_ROOT: "${DIND_SOURCE_ROOT}"
       AWS_S3_REGION_NAME: "us-east-1"
       AWS_SECRET_ACCESS_KEY: "${AWS_SECRET_ACCESS_KEY}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -82,7 +82,8 @@ services:
       LOGLEVEL: 10
       JWT_SECRET: foosecret
       REDIS_ENDPOINT: "submission-ui-redis"
-      CONVERTER_DOCKER_IMAGE: "626657773168.dkr.ecr.us-east-1.amazonaws.com/arxiv/converter:0.9"
+      # CONVERTER_DOCKER_IMAGE: "626657773168.dkr.ecr.us-east-1.amazonaws.com/arxiv/converter:0.9"
+      CONVERTER_DOCKER_IMAGE: "${CONVERTER_DOCKER_IMAGE}"
       CONVERTER_IMAGE_PULL: 0
       DIND_SOURCE_ROOT: "${DIND_SOURCE_ROOT}"
       AWS_S3_REGION_NAME: "us-east-1"
@@ -127,7 +128,8 @@ services:
       JWT_SECRET: foosecret
       NAMESPACE: "development"
       REDIS_ENDPOINT: "submission-ui-redis"
-      CONVERTER_DOCKER_IMAGE: "626657773168.dkr.ecr.us-east-1.amazonaws.com/arxiv/converter:0.9"
+    # CONVERTER_DOCKER_IMAGE: "626657773168.dkr.ecr.us-east-1.amazonaws.com/arxiv/converter:0.9"
+      CONVERTER_DOCKER_IMAGE: "${CONVERTER_DOCKER_IMAGE}"
       CONVERTER_IMAGE_PULL: 0
       DIND_SOURCE_ROOT: "${DIND_SOURCE_ROOT}"
       AWS_S3_REGION_NAME: "us-east-1"


### PR DESCRIPTION
The initial goal of ticket ARXIVNG-2787 was to create a reduced size converter image but due to the fact that each TeX Live tree is so huge it was not possible to drastically reduce the size of the current converter image (with all trees).

I ended up creating a new image for each individual TeX tree. In reality the teTeX 2 tree uses three different local texmf trees and w2c binaries over a period of a few years so I kept these together.

While the README.md instructed users to add the CONVERTER_DOCKER_IMAGE setting to choose the TeX tree the docker-compose YAML was not reading it. I fixed this so now changing converters is a matter of changing the environment variable and restarting the application.

If you set the CONVERTER_DOCKER_IMAGE to a valid image the compiler service will download it for you. The other option is to download the image before starting the application.

There are several new images in the AWS ECR repository. The image with all trees still exists as the plain arxiv/converter image.

Another PR will cover changes to converter code to improve TeX tree selection when the image does not contain all of the trees or when an appropriate date is not specified. 