### PR TITLE
ARXIVNG-2982: Use 'pipenv sync' instead of 'pipenv install'.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ FROM arxiv/base:${BASE_VERSION}
 WORKDIR /opt/arxiv/
 
 COPY Pipfile Pipfile.lock /opt/arxiv/
-RUN pipenv install && rm -rf ~/.cache/pip
+RUN pipenv sync && rm -rf ~/.cache/pip
 
 ENV PATH "/opt/arxiv:${PATH}"
 


### PR DESCRIPTION
'pipenv install' misses specific package dependencies installed in a developer's local virtual environment. 
'pipenv sync' installs the same detailed list of packages contained in the Pipfile.lock file that were installed in the environment of the last developer to commit the Pipfile.lock file.

I've made a minor change to the Dockerfile to use 'pipenv sync'.

The developer team should discuss further whether 'pipenv sync' is the preferred way to go.

This change resolves the missing package error detailed in ticket ARXIVNG-2982.