### PR TITLE
Dependency updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # arXiv submission UI
 
-ARG BASE_VERSION=0.16.5
+ARG BASE_VERSION=0.16.6
 
 FROM arxiv/base:${BASE_VERSION}
 

--- a/Dockerfile-mock-classifier
+++ b/Dockerfile-mock-classifier
@@ -1,6 +1,6 @@
 # Mock classifier
 
-ARG BASE_VERSION=0.16.5
+ARG BASE_VERSION=0.16.6
 
 FROM arxiv/base:${BASE_VERSION}
 

--- a/Dockerfile-mock-compiler
+++ b/Dockerfile-mock-compiler
@@ -1,6 +1,6 @@
 # Mock compiler
 
-ARG BASE_VERSION=0.16.5
+ARG BASE_VERSION=0.16.6
 
 FROM arxiv/base:${BASE_VERSION}
 

--- a/Dockerfile-mock-vault
+++ b/Dockerfile-mock-vault
@@ -1,6 +1,6 @@
 # Mock arXiv.org
 
-FROM arxiv/base:0.16.5
+FROM arxiv/base:0.16.6
 
 WORKDIR /opt/arxiv
 

--- a/Pipfile
+++ b/Pipfile
@@ -23,7 +23,7 @@ mypy = "==0.720"
 arxiv-auth = "~=0.4.2rc1"
 arxiv-vault = "~=0.1.1rc15"
 arxiv-submission-core = "~=0.7.2rc12"
-arxiv-base = "~=0.16.5"
+arxiv-base = "==0.16.6"
 
 [dev-packages]
 pydocstyle = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "0dc84579f44963635a8e129ddd856b99d70288ecacb8c446c23ae1786ace28b7"
+            "sha256": "664a9173c287c43cdb921d1e9ede7eb635259902367ca98552e00dd61e9bd684"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -30,10 +30,10 @@
         },
         "arxiv-base": {
             "hashes": [
-                "sha256:5b2bdfc16807c70a420b962f16b5736736a5e5ab56d50b9bf61e1ae45210b285"
+                "sha256:f7a5ff38c91bc3c8f40db500179394cbca1a3dd00d9c89c8e9e2ad63a6829664"
             ],
             "index": "pypi",
-            "version": "==0.16.7.dev0"
+            "version": "==0.16.6"
         },
         "arxiv-submission-core": {
             "hashes": [
@@ -79,17 +79,17 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:4df9e5bca38488d55f6ead4bd02702c83bf56e11c4dfde7a759c2398f2cadff6",
-                "sha256:c222c1d9301cefb1af7f7a946c48d7c66f404865f9f1951c8540499b5ce71d43"
+                "sha256:107fbf212daf1b25fff1efd6425c3e81be8db08d45e864197b0b61a6d12dbc60",
+                "sha256:e8feb81da4602c5544bee1c106624b784315ae53b28ea6565a957318b8bf160a"
             ],
-            "version": "==1.12.3"
+            "version": "==1.12.8"
         },
         "botocore": {
             "hashes": [
-                "sha256:0442da02dffa31055accd83572beb094018b97063800bd0491437a32b4f360a2",
-                "sha256:348d7e69659ef8cde2712becf270dc703af7aee07757f57559b3933c66aefee7"
+                "sha256:3aaeb36d4d0b412cb0b3fbd0399029fa13b0dd103240d34ba0ff027e6b6f2063",
+                "sha256:5e0118eac628cea1e598920cf8e5299bf9093cc0daf65b1b4f05b016e5e3a748"
             ],
-            "version": "==1.15.3"
+            "version": "==1.15.8"
         },
         "celery": {
             "hashes": [
@@ -203,10 +203,10 @@
         },
         "jmespath": {
             "hashes": [
-                "sha256:3720a4b1bd659dd2eecad0666459b9788813e032b83e7ba58578e48254e0a0e6",
-                "sha256:bde2aef6f44302dfb30320115b17d030798de8c4110e28d5cf6cf91a7a31074c"
+                "sha256:695cb76fa78a10663425d5b73ddc5714eb711157e52704d69be03b1a02ba4fec",
+                "sha256:cca55c8d153173e21baa59983015ad0daf603f9cb799904ff057bfb8ff8dc2d9"
             ],
-            "version": "==0.9.4"
+            "version": "==0.9.5"
         },
         "jsonschema": {
             "hashes": [
@@ -744,18 +744,18 @@
         },
         "soupsieve": {
             "hashes": [
-                "sha256:bdb0d917b03a1369ce964056fc195cfdff8819c40de04695a80bc813c3cfa1f5",
-                "sha256:e2c1c5dee4a1c36bcb790e0fabd5492d874b8ebd4617622c4f6a731701060dda"
+                "sha256:e914534802d7ffd233242b785229d5ba0766a7f487385e3f714446a07bf540ae",
+                "sha256:fcd71e08c0aee99aca1b73f45478549ee7e7fc006d51b37bec9e9def7dc22b69"
             ],
-            "version": "==1.9.5"
+            "version": "==2.0"
         },
         "sphinx": {
             "hashes": [
-                "sha256:525527074f2e0c2585f68f73c99b4dc257c34bbe308b27f5f8c7a6e20642742f",
-                "sha256:543d39db5f82d83a5c1aa0c10c88f2b6cff2da3e711aa849b2c627b4b403bbd9"
+                "sha256:776ff8333181138fae52df65be733127539623bb46cc692e7fa0fcfc80d7aa88",
+                "sha256:ca762da97c3b5107cbf0ab9e11d3ec7ab8d3c31377266fd613b962ed971df709"
             ],
             "index": "pypi",
-            "version": "==2.4.2"
+            "version": "==2.4.3"
         },
         "sphinx-autodoc-typehints": {
             "hashes": [
@@ -781,10 +781,10 @@
         },
         "sphinxcontrib-htmlhelp": {
             "hashes": [
-                "sha256:4670f99f8951bd78cd4ad2ab962f798f5618b17675c35c5ac3b2132a14ea8422",
-                "sha256:d4fd39a65a625c9df86d7fa8a2d9f3cd8299a3a4b15db63b50aac9e161d8eff7"
+                "sha256:3c0bc24a2c41e340ac37c85ced6dafc879ab485c095b1d65d2461ac2f7cca86f",
+                "sha256:e8f5bb7e31b2dbb25b9cc435c8ab7a79787ebf7f906155729338f3156d93659b"
             ],
-            "version": "==1.0.2"
+            "version": "==1.0.3"
         },
         "sphinxcontrib-jsmath": {
             "hashes": [

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -9,9 +9,10 @@ from arxiv.users.helpers import generate_token
 from arxiv.users.auth import scopes
 from submit.factory import create_ui_web_app
 
-logging.getLogger('arxiv.submission.services.classic.interpolate') \
-    .setLevel(logging.ERROR)
-logging.getLogger('arxiv.base.alerts').setLevel(logging.ERROR)
+logging.getLogger("arxiv.submission.services.classic.interpolate").setLevel(
+    logging.ERROR
+)
+logging.getLogger("arxiv.base.alerts").setLevel(logging.ERROR)
 
 logger = logging.getLogger(__name__)
 
@@ -20,43 +21,46 @@ app = create_ui_web_app()
 with app.app_context():
     session = classic.current_session()
     engine = classic.util.current_engine()
-    logger.info('Waiting for database server to be available')
-    logger.info(app.config['SQLALCHEMY_DATABASE_URI'])
+    logger.info("Waiting for database server to be available")
+    logger.info(app.config["SQLALCHEMY_DATABASE_URI"])
+
     wait = 2
     while True:
         try:
-            session.execute('SELECT 1')
+            session.execute("SELECT 1")
             break
         except Exception as e:
             logger.info(e)
-            logger.info(f'...waiting {wait} seconds...')
+            logger.info(f"...waiting {wait} seconds...")
+            print(f"{e}...waiting {wait} seconds...\n")
             time.sleep(wait)
             wait *= 2
 
-    logger.info('Checking for database')
-    if not engine.dialect.has_table(engine, 'arXiv_submissions'):
+    logger.info("Checking for database")
+    print("Checking for database")
+    if not engine.dialect.has_table(engine, "arXiv_submissions"):
         created_users = []
-        logger.info('Database not yet initialized; creating tables')
+        logger.info("Database not yet initialized; creating tables")
         classic.create_all()
 
-        logger.info('Populate with base data...')
+        logger.info("Populate with base data...")
         licenses = classic.bootstrap.licenses()
         for obj in licenses:
             session.add(obj)
-        logger.info('Added %i licenses', len(licenses))
+        logger.info("Added %i licenses", len(licenses))
         policy_classes = classic.bootstrap.policy_classes()
         for obj in policy_classes:
             session.add(obj)
-        logger.info('Added %i policy classes', len(policy_classes))
+        logger.info("Added %i policy classes", len(policy_classes))
         categories = classic.bootstrap.categories()
         for obj in categories:
             session.add(obj)
-        logger.info('Added %i categories', len(categories))
+        logger.info("Added %i categories", len(categories))
         users = classic.bootstrap.users(10)
         for obj in users:
             session.add(obj)
             created_users.append(obj)
-        logger.info('Added %i users', len(users))
+        logger.info("Added %i users", len(users))
         session.commit()
 
         scope = [
@@ -70,16 +74,22 @@ with app.app_context():
             scopes.DELETE_UPLOAD_FILE,
             scopes.READ_UPLOAD_LOGS,
             scopes.READ_COMPILE,
-            scopes.CREATE_COMPILE
+            scopes.CREATE_COMPILE,
+            scopes.READ_PREVIEW,
+            scopes.CREATE_PREVIEW,
         ]
         for user in created_users:
-            token = generate_token(user.user_id, user.email, user.email,
-                                   scope=scope,
-                                   first_name=user.first_name,
-                                   last_name=user.last_name,
-                                   suffix_name=user.suffix_name,
-                                   endorsements=["*.*"])
+            token = generate_token(
+                user.user_id,
+                user.email,
+                user.email,
+                scope=scope,
+                first_name=user.first_name,
+                last_name=user.last_name,
+                suffix_name=user.suffix_name,
+                endorsements=["*.*"],
+            )
             print(user.user_id, user.email, token)
 
         exit(0)
-    logger.info('Nothing to do')
+    logger.info("Nothing to do")

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -32,12 +32,10 @@ with app.app_context():
         except Exception as e:
             logger.info(e)
             logger.info(f"...waiting {wait} seconds...")
-            print(f"{e}...waiting {wait} seconds...\n")
             time.sleep(wait)
             wait *= 2
 
     logger.info("Checking for database")
-    print("Checking for database")
     if not engine.dialect.has_table(engine, "arXiv_submissions"):
         created_users = []
         logger.info("Database not yet initialized; creating tables")

--- a/docker-compose-mock-compiler.yml
+++ b/docker-compose-mock-compiler.yml
@@ -33,7 +33,8 @@ x-base-service:
 services:
 
   filemanager:
-    image: arxiv/filemanager:8846087
+    # corresponds with commit from 2020-02-27: https://github.com/arXiv/arxiv-filemanager/commit/564f852a9078138c462481c2efb7b0a070c00c05
+    image: arxiv/filemanager:564f852
     # You can uncomment these lines to build this from a local
     # repo. You may need to update `context`.
     # build:
@@ -68,7 +69,8 @@ services:
       retries: 3
 
   submission-worker:
-    image: arxiv/submission-agent:2c83801
+    # corresponds with commit from 2020-02-27: https://github.com/arXiv/arxiv-submission-core/commit/9222d6f650d9ce45a1a76961018f2ae562a37e26
+    image: arxiv/submission-agent:9222d6f
     command: "/bin/bash -c 'python -m agent.bootstrap && celery worker -A agent.worker.worker_app --loglevel=INFO -E --concurrency=2'"
     container_name: arxiv-submission-worker
     environment:
@@ -126,7 +128,8 @@ services:
       - arxiv-submission-ui
 
   submission-agent:
-    image: arxiv/submission-agent:2c83801
+    # corresponds with commit from 2020-02-27: https://github.com/arXiv/arxiv-submission-core/commit/9222d6f650d9ce45a1a76961018f2ae562a37e26
+    image: arxiv/submission-agent:9222d6f
     container_name: arxiv-submission-agent
     command: "/bin/bash -c 'python -m agent.bootstrap && python -m agent.consumer'"
     environment:
@@ -187,7 +190,8 @@ services:
       - arxiv-submission-ui
 
   submission-ui:
-    image: arxiv/submission-ui
+    # corresponds with commit from 2020-02-27: https://github.com/arXiv/arxiv-submission-ui/commit/22ae284
+    image: arxiv/submission-ui:22ae284
     build:
       context: .
       dockerfile: Dockerfile
@@ -235,7 +239,7 @@ services:
       retries: 3
 
   submission-preview:
-    image: arxiv/preview:4c4e282
+    image: arxiv/submission-preview:0.1rc1
     container_name: preview
     networks:
       - arxiv-submission-ui

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -277,7 +277,7 @@ services:
       context: .
       dockerfile: Dockerfile
       args:
-        BASE_VERSION: 0.16.1
+        BASE_VERSION: 0.16.6
     container_name: arxiv-submission-ui
     environment:
       VAULT_ENABLED: "0"
@@ -318,7 +318,7 @@ services:
       retries: 3
 
   submission-preview:
-    image: arxiv/preview:4c4e282
+    image: arxiv/submission-preview:0.1rc1
     container_name: preview
     networks:
       - arxiv-submission-ui

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,7 +33,8 @@ x-base-service:
 services:
 
   filemanager:
-    image: arxiv/filemanager:8846087
+    # corresponds with commit from 2020-02-27: https://github.com/arXiv/arxiv-filemanager/commit/564f852a9078138c462481c2efb7b0a070c00c05
+    image: arxiv/filemanager:564f852
     # You can uncomment these lines to build this from a local
     # repo. You may need to update `context`.
     # build:
@@ -117,7 +118,8 @@ services:
       retries: 3
 
   compiler-worker:
-    image: arxiv/compiler:63942bd
+    # corresponds with commit from 2020-02-27: https://github.com/arXiv/arxiv-compiler/commit/6b1b6a4e8e89e75a99b622de0d360a58d2a89598
+    image: arxiv/compiler:6b1b6a4
     # You can uncomment these lines to build this from a local
     # repo. You may need to update `context`.
     # build:
@@ -157,7 +159,8 @@ services:
       - arxiv-submission-ui
 
   submission-worker:
-    image: arxiv/submission-agent:2c83801
+    # corresponds with commit from 2020-02-27: https://github.com/arXiv/arxiv-submission-core/commit/9222d6f650d9ce45a1a76961018f2ae562a37e26
+    image: arxiv/submission-agent:9222d6f
     command: "/bin/bash -c 'python -m agent.bootstrap && celery worker -A agent.worker.worker_app --loglevel=INFO -E --concurrency=2'"
     container_name: arxiv-submission-worker
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -216,7 +216,8 @@ services:
       - arxiv-submission-ui
 
   submission-agent:
-    image: arxiv/submission-agent:2c83801
+    # corresponds with commit from 2020-02-27: https://github.com/arXiv/arxiv-submission-core/commit/9222d6f650d9ce45a1a76961018f2ae562a37e26
+    image: arxiv/submission-agent:9222d6f
     container_name: arxiv-submission-agent
     command: "/bin/bash -c 'python -m agent.bootstrap && python -m agent.consumer'"
     environment:
@@ -275,6 +276,7 @@ services:
       - arxiv-submission-ui
 
   submission-ui:
+    # corresponds with commit from 2020-02-27: https://github.com/arXiv/arxiv-submission-ui/commit/22ae284
     image: arxiv/submission-ui:22ae284
     build:
       context: .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -272,7 +272,7 @@ services:
       - arxiv-submission-ui
 
   submission-ui:
-    image: arxiv/submission-ui
+    image: arxiv/submission-ui:22ae284
     build:
       context: .
       dockerfile: Dockerfile

--- a/submit/templates/submit/classification.html
+++ b/submit/templates/submit/classification.html
@@ -90,7 +90,7 @@
           <div class="message-body">
             <p class="is-size-6">
               <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 192 512" class="icon filter-grey" role="presentation"><path d="M20 424.229h20V279.771H20c-11.046 0-20-8.954-20-20V212c0-11.046 8.954-20 20-20h112c11.046 0 20 8.954 20 20v212.229h20c11.046 0 20 8.954 20 20V492c0 11.046-8.954 20-20 20H20c-11.046 0-20-8.954-20-20v-47.771c0-11.046 8.954-20 20-20zM96 0C56.235 0 24 32.235 24 72s32.235 72 72 72 72-32.235 72-72S135.764 0 96 0z"/></svg>
-              Select a category from the dropdown to view it's description
+              Select a category from the dropdown to view its description
             </p>
           </div>
         </div>


### PR DESCRIPTION
This PR intended to "catch up" the submission UI dependencies so we are closer to the actual alpha version testers will see. This not only includes the submission UI itself, but also the docker-compose files. I've updated the docker-compose files to point to more/most recent versions of the docker images that I recently pushed; in most cases will point to the most recent commit in the respective repositories. I expect we'll continue to update these as we get closer to testing. 

I've tested with the `docker-compose-mock-compiler.yml` variant. It would be great if reviewers could test the full submission process with the docker-compose variant. You'll likely need to remove existing images first (with `docker-compose rm -v`).

If you are using a tool like Requestly to store your authorization token, you may also need to update your token so that you can test the "preview" stage. This is because the docker-compose files pull in a newer version of arxiv-auth and arxiv-submission-preview that have new permission scopes for creating and reading the submission previews.

![Screenshot 2020-02-28 08 27 18](https://user-images.githubusercontent.com/746253/75553531-9091cf80-5a06-11ea-97ed-0f5413255d22.png)
![Screenshot 2020-02-28 08 29 27](https://user-images.githubusercontent.com/746253/75553537-938cc000-5a06-11ea-9e59-cf5a6a24a76d.png)
