### PR TITLE
ARXIVNG-3018: Submission UI readme updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ to come up. If you are redirected to the production ArXiv.org login page,
 then your browser is not sending a valid JWT to localhost.
 
 To stop the service, and remove the docker compose containers, you can Ctrl-C or "stop", and then "rm".
-To remove images so they will be rebuilt, use 'docker prune' or 'docker rmi':
+To remove images so they will be rebuilt, use prune or 'docker rmi':
 ```bash
 docker-compose -f docker-compose-mock-compiler.yml stop
 docker-compose -f docker-compose-mock-compiler.yml rm -v

--- a/README.md
+++ b/README.md
@@ -303,42 +303,44 @@ development server for quicker cycles.
 So you can start the submission UI in dev mode with something like:
 
 ```bash
-$ cd arxiv-submission-ui
-$ # Check out branch you are evaluating and be sure to pull recent changes
-$ git pull
-$ pipenv install --dev
-$ export VAULT_ENABLED="0"
-$ export NAMESPACE="development"
-$ export LOGLEVEL=10
-$ export JWT_SECRET=foosecret
-$ export SESSION_COOKIE_SECURE=0
-$ export CLASSIC_DATABASE_URI="mysql+mysqldb://foouser:foopass@127.0.0.1:3307/submission?charset=utf8mb4"
-$ export WAIT_FOR_SERVICES=0
-$ export WAIT_ON_STARTUP=0
-$ export FILEMANAGER_ENDPOINT="http://localhost:8001/filemanager/api"
-$ export FILEMANAGER_CONTENT_PATH="/{source_id}/content"
-$ export COMPILER_ENDPOINT="http://localhost:8100/"
-$ export COMPILER_VERIFY=0
-$ export PREVIEW_ENDPOINT='http://localhost:9001/'
-$ export PREVIEW_VERIFY=0
-$ export KINESIS_STREAM="SubmissionEvents"
-$ export KINESIS_VERIFY=0
-$ export KINESIS_ENDPOINT="https://localhost:4568"
-$ export KINESIS_START_TYPE="TRIM_HORIZON"
-$ FLASK_APP=app.py FLASK_DEBUG=1 pipenv run flask run
+cd arxiv-submission-ui
+# Check out branch you are evaluating and be sure to pull recent changes
+git pull
+pipenv install --dev
+export VAULT_ENABLED="0"
+export NAMESPACE="development"
+export LOGLEVEL=10
+export JWT_SECRET=foosecret
+export SESSION_COOKIE_SECURE=0
+export CLASSIC_DATABASE_URI="mysql+mysqldb://foouser:foopass@127.0.0.1:3307/submission?charset=utf8mb4"
+export WAIT_FOR_SERVICES=0
+export WAIT_ON_STARTUP=0
+export FILEMANAGER_ENDPOINT="http://localhost:8001/filemanager/api"
+export FILEMANAGER_CONTENT_PATH="/{source_id}/content"
+export COMPILER_ENDPOINT="http://localhost:8100/"
+export COMPILER_VERIFY=0
+export PREVIEW_ENDPOINT='http://localhost:9001/'
+export PREVIEW_VERIFY=0
+export KINESIS_STREAM="SubmissionEvents"
+export KINESIS_VERIFY=0
+export KINESIS_ENDPOINT="https://localhost:4568"
+export KINESIS_START_TYPE="TRIM_HORIZON"
+export FLASK_APP=app.py
+export FLASK_DEBUG=1
+pipenv run flask run
 ```
 
 And access it at http://localhost:5000.
 
 ## Generating an auth token
 
-You MUST create a valid token to run the UI/FM development environment. The easiest way to do this is use the generate_token.py script in arxiv-auth.
+You MUST create a valid token to run the UI/FM development environment. The easiest way to do this is use the generate-token script in arxiv-auth. Adjust the defaults for 'Endorsement categories' and 'Authorization scope', and add the JWT to requestly for localhost:5000:
 
 ```bash
 $ cd arxiv-auth
 $ git pull
 $ pipenv install ./users
-$ JWT_SECRET=foosecret pipenv run python generate_token.py
+$ JWT_SECRET=foosecret pipenv run python users/bin/generate-token
 Numeric user ID: 1234
 Email address: jdoe@cornell.edu
 Username: Jane Doe

--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ submission workflow.
 
 ## Quick start with mock compilation
 
+The mock compilation configuration will run with Docker's default setting of 2GB memory.
+If you have the resources available, it's recommended to increase to 4GB now, to avoid later issues:
+[add memory for Docker on a Mac](https://docs.docker.com/docker-for-mac/#resources).
+
 Submission involves several back-end services, worker processes and
 the UI application itself. The easiest way to spin up all of this
 stuff with correct wiring is to use the provided docker-compose
@@ -49,11 +53,20 @@ get a response right away, the UI is probably still waiting for something
 to come up. If you are redirected to the production ArXiv.org login page,
 then your browser is not sending a valid JWT to localhost.
 
-To stop the service, and remove the docker compose containers, you can Ctrl-C or "stop", and then "rm":
+To stop the service, and remove the docker compose containers, you can Ctrl-C or "stop", and then "rm".
+To remove images so they will be rebuilt, use 'docker prune' or 'docker rmi':
 ```bash
 docker-compose -f docker-compose-mock-compiler.yml stop
 docker-compose -f docker-compose-mock-compiler.yml rm -v
+docker system prune
 ```
+
+### Common issues getting started
+
+- If localhost is not working:
+  - You may have a local process running on a port. E.g.: With docker compose stopped, check for a running mysql with 'brew services' or 'lsof -i :3306' or 'ps aux | grep mysqld'.
+  - Increase the memory, up to 4GB.
+- If you are redirected from localhost to arxiv.org, check your JWT configuration.
 
 ### About the mock compiler service
 

--- a/README.md
+++ b/README.md
@@ -39,12 +39,15 @@ arxiv-submission-ui     | 1 picoline2058@gmail.com _JWT_STARTS_HERE_AND_GOES_ON_
 ```
 You will need to pass the JWT in the ``Authorization`` header.
 This is a valid session so you can use the submission UI.
-For Chrome, try [Requestly](https://www.requestly.in/).
-In Requestly, you can limit the url to localhost, so the JWT is not sent to additional websites.
+For Chrome, try the [Requestly](https://www.requestly.in/) plugin, where you:
+- Create a rule to modify headers
+- Add a request header of "Authorization", with a value as the JWT you found in the logs.
+- Add a value for "request url contains" as localhost:8000.
 
 You should be able to access the UI at http://localhost:8000. If you don't
 get a response right away, the UI is probably still waiting for something
-to come up. If you are redirected to the production archive login page, the JWT is not being sent.
+to come up. If you are redirected to the production ArXiv.org login page,
+then your browser is not sending a valid JWT to localhost.
 
 To stop the service, and remove the docker compose containers, you can Ctrl-C or "stop", and then "rm":
 ```bash
@@ -130,9 +133,8 @@ To do this,
 To test if you have access to ECR run:
 `aws ecr list-images --repository-name arxiv/converter`
 You should get a response of no error and a list of docker images.
-
-If you installed credentials with `aws configure`,
-you may need to remove fake credentials in your shell, for example:
+- You can install your credentials in ~/.aws/ with `aws configure`.
+- You may need to remove the fake credentials from above, in your shell, for example:
 ```bash
 unset AWS_ACCESS_KEY_ID  AWS_SECRET_ACCESS_KEY
 ```
@@ -191,10 +193,10 @@ In order to let the compiler service download a converter image simply set (incl
 ```bash
 export CONVERTER_DOCKER_IMAGE=626657773168.dkr.ecr.us-east-1.amazonaws.com/arxiv/converter-2009:0.1.0
 ```
-Login to the AWS ECR server to download docker images with one of these:
+Login to the AWS ECR server using the AWS CLI version 1 or 2:
 ```bash
-aws ecr get-login --no-include-email --region us-east-1
-aws ecr get-login-password | docker login --username AWS --password-stdin https://626657773168.dkr.ecr.us-east-1.amazonaws.com
+aws ecr get-login --no-include-email --region us-east-1      # aws-cli/1.x
+aws ecr get-login-password | docker login --username AWS --password-stdin https://626657773168.dkr.ecr.us-east-1.amazonaws.com # aws-cli/2.x
 ```
 To download manually execute the pull command with the appropriate converter image specification:
 ```bash


### PR DESCRIPTION
I found the submission-ui readme very helpful, and the docker-compose config has made it easy to get all those pieces up and running.

Along the way, there were a couple of things I got caught on:
- I left a local version of mysql running, which collided with the docker mysql ports, and wasn’t obvious from the logs.
- I didn’t read past the full-compiler details, to find the JWT instructions, so was redirected to production login initially.
- I had docker crash twice when running the full compiler version, and increased the ram to 4g. I’m not sure its needed or related to other issues.

I was able to ‘aws ecr list…’, but not 'docker pull …dkr.ecr…’. The fix was: ‘aws ecr get-login.’ I’m guessing the first ran by reading my ~/.aws/config. I assume there isn’t anything exposed here.

I have a few changes that may be helpful for the next person getting started. I tried things that seem like obvious tangents now, but a few days ago were unknown possibilities. I suggest reorganizing the readme and adding two milestones. First get the mock-compiler running, then get the full compiler running. I think this will narrow down the options. There’s less background initially, but I like that the instructions fit on a single screen. How does this sound? 