### PR TITLE
ARXIVNG-3005: Fix bug where user couldn't escape upload-files page

### DIFF
--- a/submit/controllers/ui/new/upload.py
+++ b/submit/controllers/ui/new/upload.py
@@ -153,8 +153,7 @@ def upload_files(method: str, params: MultiDict, session: Session,
 class UploadForm(csrf.CSRFForm):
     """Form for uploading files."""
 
-    file = FileField('Choose a file...',
-                     validators=[DataRequired()])
+    file = FileField('Choose a file...')
     ancillary = BooleanField('Ancillary')
 
 


### PR DESCRIPTION
To continue to the next step of processing files, the user needs to have uploaded valid files. This removes the check for a file being selected in the form, as the user is redirected back to the page after uploading a file.
There are existing filemanager checks which set stay_on_this_stage to prevent the user from continuing. The default is to allow the user to continue, so I haven't added any calls to ready_for_next.  