### PR TITLE
ARXIVNG-2968: Improve AutoTeX log highlighting for "File Not Found" and "Emergency Stop" TeX errors.

### DIFF
--- a/submit/filters/tex_filters.py
+++ b/submit/filters/tex_filters.py
@@ -17,6 +17,14 @@ DISABLE_HPDFLATEX = r'(\~+\sRunning hpdflatex.*\s\~+)'
 
 RUN_ORDER = ['last', 'first', 'second', 'third', 'fourth']
 
+def initialize_error_summary() -> str:
+    """Initialize the error_summary string with desired markuop."""
+    error_summary = '\nSummary of <span class="tex-fatal">Critical Errors:</span>\n\n<ul>\n'
+    return error_summary
+
+def finalize_error_summary(error_summary: str) -> str:
+    error_summary = error_summary + "</ul>\n"
+    return error_summary
 
 def compilation_log_display(autotex_log: str, submission_id: int,
                             compilation_status: str) -> str:
@@ -241,16 +249,27 @@ def compilation_log_display(autotex_log: str, submission_id: int,
         ['ignore', 'warning', 'first'],
         ['ignore', 'undefined', 'first'],
     ]
-    abort_markup = False
+
+    # Try to create summary containing errors deemed important for user
+    # to address.
     error_summary = ''
+
+    # Keep track of any errors we've already added to error_summary
+    abort_markup = False
+    xetex_luatex_abort = False
+    emergency_stop = False
+    missing_file = False
     missing_font_markup = False
     rerun_markup = False
+
+    # Collect some state about
 
     final_run_had_errors = False
     final_run_had_warnings = False
 
     line_by_line = autotex_log.splitlines()
 
+    # Enable markup. Program will turn off markup for extraneous run.
     markup_enabled = True
 
     for line in line_by_line:
@@ -258,7 +277,7 @@ def compilation_log_display(autotex_log: str, submission_id: int,
         # Escape any HTML contained in the log
         line = html.escape(line)
 
-        # Disable markup for TeX runs we do not want to markup
+        # Disable markup for TeX runs we do not want to mark up
         for regex in disable_markup:
 
             if re.search(regex, line, re.IGNORECASE):
@@ -355,36 +374,41 @@ def compilation_log_display(autotex_log: str, submission_id: int,
                     if level == 'danger' or level == 'fatal':
                         final_run_had_errors = True
 
-                if actual_level == 'abort':
+                # Currently XeTeX/LuaTeX are the only full abort case.
+                if not abort_markup and actual_level == 'abort' \
+                        and (re.search('Fatal fontspec error: "cannot-use-pdftex"', line)
+                             or re.search("The fontspec package requires either XeTeX or LuaTeX.", line)
+                             or re.search("{cannot-use-pdftex}", line)):
 
                     if error_summary == '':
-                        error_summary = error_summary \
-                                        + '\nSummary of <span class="tex-fatal">Critical Errors:</span>\n\n'
+                        error_summary = initialize_error_summary()
                     else:
                         error_summary = error_summary + '\n'
 
                     error_summary = error_summary + (
-                        "\tAt the current time arXiv does not support XeTeX/LuaTeX.\n\n"
+                        "\t<li>At the current time arXiv does not support XeTeX/LuaTeX.\n\n"
                         '\tIf you believe that your submission requires a compilation '
                         'method \n\tunsupported by arXiv, please contact '
                         '<span class=\"tex-help\">help@arxiv.org</span> for '
                         '\n\tmore information and provide us with this '
-                        f'submit/{submission_id} identifier.\n\n')
+                        f'submit/{submission_id} identifier.</li>')
+
+                    xetex_luatex_abort = True
                     abort_markup = True
 
                 # Hack alert - Cringe - Handle missfont while I'm working on converter.
                 # TODO: Need to formalize detecting errors that need to be
                 # TODO: reported in error summary
-                if not missing_font_markup and level == 'fatal' and re.search("missfont.log present", line):
+                if not missing_font_markup and level == 'fatal' \
+                        and re.search("missfont.log present", line):
 
                     if error_summary == '':
-                        error_summary = error_summary \
-                                        + '\nSummary of <span class="tex-fatal">Critical Errors:</span>\n\n'
+                        error_summary = initialize_error_summary()
                     else:
                         error_summary = error_summary + '\n'
 
                     error_summary = error_summary + (
-                        "\tA font required by your paper is not available. "
+                        "\t<li>A font required by your paper is not available. "
                         "You may try to \n\tinclude a non-standard font or "
                         "substitue an alternative font. \n\tSee <span "
                         "class=\"tex-help\"><a href=\"https://arxiv.org/"
@@ -392,23 +416,24 @@ def compilation_log_display(autotex_log: str, submission_id: int,
                         "this is due to a problem with \n\tour system, please "
                         "contact <span class=\"tex-help\">help@arxiv.org</span>"
                         " with details \n\tand provide us with this "
-                        f'submission identifier: submit/{submission_id}.\n\n')
+                        f'submission identifier: submit/{submission_id}.'
+                        '</li>')
 
                     missing_font_markup = True
 
                 # Hack alert - detect common problem where we need another TeX run
-                if not rerun_markup and level == 'danger' and re.search("rerunfilecheck|rerun", line) \
+                if not rerun_markup and level == 'danger' \
+                        and re.search("rerunfilecheck|rerun", line) \
                         and not re.search(r"get arXiv to do 4 passes\: Label\(s\) may have changed", line) \
                         and not re.search(r"oberdiek", line):
 
                     if error_summary == '':
-                        error_summary = error_summary \
-                                        + '\nSummary of <span class="tex-fatal">Critical Errors:</span>\n\n'
+                        error_summary = initialize_error_summary()
                     else:
                         error_summary = error_summary + '\n'
 
                     error_summary = error_summary + (
-                        "\tAnalysis of the compilation log indicates "
+                        "\t<li>Analysis of the compilation log indicates "
                         "your submission \n\tmay need an additional TeX run. "
                         "Please add the following line \n\tto your source in "
                         "order to force an additional TeX run:\n\n"
@@ -416,7 +441,7 @@ def compilation_log_display(autotex_log: str, submission_id: int,
                         "to do 4 passes: Label(s) may have changed. Rerun}</span>"
                         "\n\n\tAdd the above line just before <span "
                         "class=\"tex-help\">\end{document}</span> directive."
-                        "\n\n.")
+                        "/li>")
 
                     # Significant enough that we should turn on warning
                     final_run_had_warnings = True
@@ -424,10 +449,59 @@ def compilation_log_display(autotex_log: str, submission_id: int,
                     # Only do this once
                     rerun_markup = True
 
+                # Missing file needs to be kicked up in visibility and displayed in
+                # compilation summary.
+                #
+                # There is an issue with the AutoTeX log where parts of the log
+                # may be getting truncated. Therefore, for this error, we will
+                # report the error if it occurs during any run.
+                #
+                # We might want to refine the activiation criteria for this
+                # warning once the issue is resolved with truncated log.
+                if not missing_file and level == 'danger' \
+                        and re.search('file (.*) not found', line, re.IGNORECASE):
+
+                    if error_summary == '':
+                        error_summary = initialize_error_summary()
+                    else:
+                        error_summary = error_summary + '\n'
+
+                    error_summary = error_summary + (
+                        "<li>\tA file required by your submission was not found."
+                        f"\n\t{line}\n\tPlease upload any missing files, or "
+                        "correct any file naming issues, and then reprocess"
+                        " your submission.</li>")
+
+                    # Don't activate this so we can see bug I created above...
+                    missing_file = True
+
+                # Emergency stop tends to hand-in-hand with the file not found error.
+                # If we havve already reported on the file not found error then
+                # we won't add yet another warning about emergency stop.
+                if not missing_file and not emergency_stop and level == 'danger' \
+                        and re.search('emergency stop', line, re.IGNORECASE):
+
+                    if error_summary == '':
+                        error_summary = initialize_error_summary()
+                    else:
+                        error_summary = error_summary + '\n'
+
+                    error_summary = error_summary + (
+                        "\t<li>We detected an emergency stop during one of the TeX"
+                        " compilation runs. Please review the compilation log"
+                        " to determie whether there is a serious issue with "
+                        "your submission source.</li>")
+
+                    emergency_stop = True
+
+                # We found a match so we are finished with this line
                 break
 
         # Append line to new marked up log
         new_log = new_log + line + '\n'
+
+    if error_summary:
+        error_summary = finalize_error_summary(error_summary)
 
     # Now that we are done highlighting the autotex log we are able to roughly
     # determine/refine the status of a successful compilation.
@@ -437,7 +511,10 @@ def compilation_log_display(autotex_log: str, submission_id: int,
     status_class = 'success'
     if compilation_status == 'failed':
         status_class = 'fatal'
-        display_status = "Failed"
+        if xetex_luatex_abort:
+            display_status = "Failed: XeTeX/LuaTeX are not supported at current time."
+        else:
+            display_status = "Failed"
     elif compilation_status == 'succeeded':
         if final_run_had_errors and not final_run_had_warnings:
             display_status = ("Succeeded with possible errors. "
@@ -464,6 +541,6 @@ def compilation_log_display(autotex_log: str, submission_id: int,
     # Put together a nice report, list TeX runs, markup info, and marked up log.
     # In future we can add 'Recommendation' section or collect critical errors.
     new_log = run_summary + status_line + error_summary + key_summary \
-              + '\n\nMarked Up Log:\n\n' + new_log
+              + '\n\n<b>Marked Up Log:</b>\n\n' + new_log
 
     return new_log

--- a/submit/filters/tex_filters.py
+++ b/submit/filters/tex_filters.py
@@ -513,6 +513,8 @@ def compilation_log_display(autotex_log: str, submission_id: int,
         status_class = 'fatal'
         if xetex_luatex_abort:
             display_status = "Failed: XeTeX/LuaTeX are not supported at current time."
+        elif missing_file:
+            display_status = "Failed: File not found."
         else:
             display_status = "Failed"
     elif compilation_status == 'succeeded':


### PR DESCRIPTION
This ticket [ ARXIVNG-2968 ] was originally scoped with addressing the problem of submissions that fail but still seem to generate a PDF (bad).

The problem (or one problem) with the compiler service not signaling errors properly was fixed with recent changes to the converter/compilation image. I'm no longer able to generate a PDF given the example submission originally provided to demonstrate the issue.

The "File Not Found"  and the "Emergency Stop" errors are currently highlighted in the log body but not extracted and displayed in the log summary section.

In this PR I've added messages for the "File Not Found" and "Emergency Stop" errors to the log summary section. Since these two errors often occur together I only display one of the errors, the "File Not Found" error, when they occur together. We'll need to find another submission with an emergency stop to demonstrate the other message.

I've also improved the error message displayed when a user uploads XeTeX/LuaTeX source ( currently not supported).

![Screen Shot 2020-03-05 at 4 21 22 PM](https://user-images.githubusercontent.com/2325384/76026747-6310be80-5efd-11ea-847c-3e4be10424b4.png)

XeTeX/LuaTeX:

![Screen Shot 2020-03-05 at 3 07 03 PM](https://user-images.githubusercontent.com/2325384/76026905-ac610e00-5efd-11ea-8733-898baddef508.png)

I expect Shamsi might be the most interested in the visible log highlighting changes. I'm definitely interested in comments and suggestions to improve this feature of the process page.

Note: At the current time the highlighting routine is independent of the process HTML. That is, things discovered in the markup routine can't be communicated effectively to the processing step, such as to change the state of the submission. In the case where a submission compiles successfully, but we discover something really bad in the log highlighting, it would be nice to 'update' the status of the submission to failed status. Ideas for future improvements.